### PR TITLE
Fix copy button icon-only swap

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -11,7 +11,7 @@ import AsciiLogo from '../components/AsciiLogo.astro';
       <p class="text-lg text-text-muted mb-10 leading-relaxed" style="text-wrap: pretty">Investigate topics, write papers, run experiments, review research, audit codebases &mdash; every output cited and source-grounded</p>
       <button id="copy-btn" class="group inline-flex items-center justify-between gap-3 bg-surface rounded-lg px-5 py-3 mb-8 font-mono text-sm hover:border-accent/40 hover:text-accent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-lg border border-border max-w-full" aria-label="Copy install command">
         <code class="text-accent text-left">curl -fsSL https://feynman.is/install | bash</code>
-        <span class="shrink-0 text-text-dim group-hover:text-accent transition-colors" aria-hidden="true">
+        <span id="copy-icon" class="shrink-0 text-text-dim group-hover:text-accent transition-colors" aria-hidden="true">
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></svg>
         </span>
       </button>
@@ -151,10 +151,10 @@ import AsciiLogo from '../components/AsciiLogo.astro';
   <script is:inline>
     document.getElementById('copy-btn').addEventListener('click', function() {
       navigator.clipboard.writeText('curl -fsSL https://feynman.is/install | bash');
-      this.innerHTML = '<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg>';
-      var btn = this;
+      var icon = document.getElementById('copy-icon');
+      icon.innerHTML = '<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg>';
       setTimeout(function() {
-        btn.innerHTML = '<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+        icon.innerHTML = '<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
       }, 2000);
     });
   </script>


### PR DESCRIPTION
## Summary
- Copy button on homepage now only swaps the icon to a checkmark on click, instead of replacing the entire button content

🤖 Generated with [Claude Code](https://claude.com/claude-code)