### PR TITLE
fix(windows): prevent ERR_UNSUPPORTED_ESM_URL_SCHEME in CLI bootstrap

### DIFF
--- a/bin/feynman.js
+++ b/bin/feynman.js
@@ -22,5 +22,5 @@ if (compareNodeVersions(parseNodeVersion(process.versions.node), parseNodeVersio
   console.error("curl -fsSL https://feynman.is/install | bash");
   process.exit(1);
 }
-await import("../scripts/patch-embedded-pi.mjs");
-await import("../dist/index.js");
+await import(new URL("../scripts/patch-embedded-pi.mjs", import.meta.url).href);
+await import(new URL("../dist/index.js", import.meta.url).href);

--- a/scripts/patch-embedded-pi.mjs
+++ b/scripts/patch-embedded-pi.mjs
@@ -156,6 +156,21 @@ function resolveExecutable(name, fallbackPaths = []) {
 		if (existsSync(candidate)) return candidate;
 	}
 
+	if (process.platform === "win32") {
+		const result = spawnSync("where", [name], {
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+		});
+		if (result.status === 0) {
+			const resolved = result.stdout
+				.split(/\r?\n/)
+				.map((entry) => entry.trim())
+				.find(Boolean);
+			if (resolved) return resolved;
+		}
+		return null;
+	}
+
 	const result = spawnSync("sh", ["-lc", `command -v ${name}`], {
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "ignore"],


### PR DESCRIPTION
This PR resolves Windows startup failures caused by ESM import path handling and shell-based executable lookup.

### Changes
- `bin/feynman.js`
  - Replaced dynamic imports with file-URL-based imports:
    - `import(new URL("../scripts/patch-embedded-pi.mjs", import.meta.url).href)`
    - `import(new URL("../dist/index.js", import.meta.url).href)`
- `scripts/patch-embedded-pi.mjs`
  - Added Windows-specific executable detection using `where`.
  - Kept existing `sh -lc "command -v ..."` logic for non-Windows platforms.

### Why
On Windows, absolute paths like `C:\...` are not valid ESM module URLs unless converted to `file://` URLs.  
Also, `sh` may not be available on Windows, so executable lookup should use `where`.

### Validation
- `npm run build`
- `node .\bin\feynman.js --help`
- CLI starts without `ERR_UNSUPPORTED_ESM_URL_SCHEME`.