### PR TITLE
test: add coverage for config/paths and catalog snapshot edge cases

### DIFF
--- a/tests/catalog-snapshot.test.ts
+++ b/tests/catalog-snapshot.test.ts
@@ -1,0 +1,117 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildModelStatusSnapshotFromRecords } from "../src/model/catalog.js";
+
+test("buildModelStatusSnapshotFromRecords returns empty guidance when model is set and valid", () => {
+	const snapshot = buildModelStatusSnapshotFromRecords(
+		[{ provider: "anthropic", id: "claude-opus-4-6" }],
+		[{ provider: "anthropic", id: "claude-opus-4-6" }],
+		"anthropic/claude-opus-4-6",
+	);
+
+	assert.equal(snapshot.currentValid, true);
+	assert.equal(snapshot.current, "anthropic/claude-opus-4-6");
+	assert.equal(snapshot.guidance.length, 0);
+});
+
+test("buildModelStatusSnapshotFromRecords emits guidance when no models are available", () => {
+	const snapshot = buildModelStatusSnapshotFromRecords([], [], undefined);
+
+	assert.equal(snapshot.currentValid, false);
+	assert.equal(snapshot.current, undefined);
+	assert.equal(snapshot.recommended, undefined);
+	assert.ok(
+		snapshot.guidance.some((line) => line.includes("No authenticated Pi models")),
+		"expected guidance about no authenticated models",
+	);
+});
+
+test("buildModelStatusSnapshotFromRecords emits guidance when no default model is set", () => {
+	const snapshot = buildModelStatusSnapshotFromRecords(
+		[{ provider: "openai", id: "gpt-5.4" }],
+		[{ provider: "openai", id: "gpt-5.4" }],
+		undefined,
+	);
+
+	assert.equal(snapshot.currentValid, false);
+	assert.equal(snapshot.current, undefined);
+	assert.ok(
+		snapshot.guidance.some((line) => line.includes("No default research model")),
+		"expected guidance about missing default model",
+	);
+});
+
+test("buildModelStatusSnapshotFromRecords marks provider as configured only when it has available models", () => {
+	const snapshot = buildModelStatusSnapshotFromRecords(
+		[
+			{ provider: "anthropic", id: "claude-opus-4-6" },
+			{ provider: "openai", id: "gpt-5.4" },
+		],
+		[{ provider: "openai", id: "gpt-5.4" }],
+		"openai/gpt-5.4",
+	);
+
+	const anthropicProvider = snapshot.providers.find((p) => p.id === "anthropic");
+	const openaiProvider = snapshot.providers.find((p) => p.id === "openai");
+
+	assert.ok(anthropicProvider, "anthropic provider should appear in list");
+	assert.equal(anthropicProvider!.configured, false, "anthropic should not be configured");
+	assert.equal(anthropicProvider!.supportedModels, 1);
+	assert.equal(anthropicProvider!.availableModels, 0);
+
+	assert.ok(openaiProvider, "openai provider should appear in list");
+	assert.equal(openaiProvider!.configured, true, "openai should be configured");
+	assert.equal(openaiProvider!.supportedModels, 1);
+	assert.equal(openaiProvider!.availableModels, 1);
+});
+
+test("buildModelStatusSnapshotFromRecords marks provider as current when selected model belongs to it", () => {
+	const snapshot = buildModelStatusSnapshotFromRecords(
+		[
+			{ provider: "anthropic", id: "claude-opus-4-6" },
+			{ provider: "openai", id: "gpt-5.4" },
+		],
+		[
+			{ provider: "anthropic", id: "claude-opus-4-6" },
+			{ provider: "openai", id: "gpt-5.4" },
+		],
+		"anthropic/claude-opus-4-6",
+	);
+
+	const anthropicProvider = snapshot.providers.find((p) => p.id === "anthropic");
+	const openaiProvider = snapshot.providers.find((p) => p.id === "openai");
+
+	assert.equal(anthropicProvider!.current, true, "anthropic should be current");
+	assert.equal(openaiProvider!.current, false, "openai should not be current");
+});
+
+test("buildModelStatusSnapshotFromRecords returns available models sorted by research preference", () => {
+	const snapshot = buildModelStatusSnapshotFromRecords(
+		[
+			{ provider: "openai", id: "gpt-5.4" },
+			{ provider: "anthropic", id: "claude-opus-4-6" },
+		],
+		[
+			{ provider: "openai", id: "gpt-5.4" },
+			{ provider: "anthropic", id: "claude-opus-4-6" },
+		],
+		undefined,
+	);
+
+	// claude-opus-4-6 is ranked higher in RESEARCH_MODEL_PREFERENCES
+	assert.equal(snapshot.availableModels[0], "anthropic/claude-opus-4-6");
+	assert.equal(snapshot.availableModels[1], "openai/gpt-5.4");
+	assert.equal(snapshot.recommended, "anthropic/claude-opus-4-6");
+});
+
+test("buildModelStatusSnapshotFromRecords sets currentValid false when current model is not in available list", () => {
+	const snapshot = buildModelStatusSnapshotFromRecords(
+		[{ provider: "anthropic", id: "claude-opus-4-6" }],
+		[],
+		"anthropic/claude-opus-4-6",
+	);
+
+	assert.equal(snapshot.currentValid, false);
+	assert.equal(snapshot.current, "anthropic/claude-opus-4-6");
+});

--- a/tests/config-paths.test.ts
+++ b/tests/config-paths.test.ts
@@ -1,0 +1,96 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import {
+	getFeynmanHome,
+	getFeynmanAgentDir,
+	getFeynmanMemoryDir,
+	getFeynmanStateDir,
+	getDefaultSessionDir,
+	getBootstrapStatePath,
+	ensureFeynmanHome,
+} from "../src/config/paths.js";
+
+test("getFeynmanHome uses FEYNMAN_HOME env var when set", () => {
+	const previous = process.env.FEYNMAN_HOME;
+	try {
+		process.env.FEYNMAN_HOME = "/custom/home";
+		assert.equal(getFeynmanHome(), resolve("/custom/home", ".feynman"));
+	} finally {
+		if (previous === undefined) {
+			delete process.env.FEYNMAN_HOME;
+		} else {
+			process.env.FEYNMAN_HOME = previous;
+		}
+	}
+});
+
+test("getFeynmanHome falls back to homedir when FEYNMAN_HOME is unset", () => {
+	const previous = process.env.FEYNMAN_HOME;
+	try {
+		delete process.env.FEYNMAN_HOME;
+		const home = getFeynmanHome();
+		assert.ok(home.endsWith(".feynman"), `expected path ending in .feynman, got: ${home}`);
+		assert.ok(!home.includes("undefined"), `expected no 'undefined' in path, got: ${home}`);
+	} finally {
+		if (previous === undefined) {
+			delete process.env.FEYNMAN_HOME;
+		} else {
+			process.env.FEYNMAN_HOME = previous;
+		}
+	}
+});
+
+test("getFeynmanAgentDir resolves to <home>/agent", () => {
+	assert.equal(getFeynmanAgentDir("/some/home"), resolve("/some/home", "agent"));
+});
+
+test("getFeynmanMemoryDir resolves to <home>/memory", () => {
+	assert.equal(getFeynmanMemoryDir("/some/home"), resolve("/some/home", "memory"));
+});
+
+test("getFeynmanStateDir resolves to <home>/.state", () => {
+	assert.equal(getFeynmanStateDir("/some/home"), resolve("/some/home", ".state"));
+});
+
+test("getDefaultSessionDir resolves to <home>/sessions", () => {
+	assert.equal(getDefaultSessionDir("/some/home"), resolve("/some/home", "sessions"));
+});
+
+test("getBootstrapStatePath resolves to <home>/.state/bootstrap.json", () => {
+	assert.equal(
+		getBootstrapStatePath("/some/home"),
+		resolve("/some/home", ".state", "bootstrap.json"),
+	);
+});
+
+test("ensureFeynmanHome creates all required subdirectories", () => {
+	const root = mkdtempSync(join(tmpdir(), "feynman-paths-"));
+	try {
+		const home = join(root, "home");
+		ensureFeynmanHome(home);
+
+		assert.ok(existsSync(home), "home dir should exist");
+		assert.ok(existsSync(join(home, "agent")), "agent dir should exist");
+		assert.ok(existsSync(join(home, "memory")), "memory dir should exist");
+		assert.ok(existsSync(join(home, ".state")), ".state dir should exist");
+		assert.ok(existsSync(join(home, "sessions")), "sessions dir should exist");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("ensureFeynmanHome is idempotent when dirs already exist", () => {
+	const root = mkdtempSync(join(tmpdir(), "feynman-paths-"));
+	try {
+		const home = join(root, "home");
+		ensureFeynmanHome(home);
+		// Calling again should not throw
+		assert.doesNotThrow(() => ensureFeynmanHome(home));
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## Summary

- **`tests/config-paths.test.ts`** (new): Adds tests for `src/config/paths.ts`, a module that was entirely untested. Covers:
  - `getFeynmanHome` respects the `FEYNMAN_HOME` env var and falls back to `homedir()` correctly
  - All subdirectory path helpers (`getFeynmanAgentDir`, `getFeynmanMemoryDir`, `getFeynmanStateDir`, `getDefaultSessionDir`, `getBootstrapStatePath`)
  - `ensureFeynmanHome` creates all required subdirectories on disk
  - `ensureFeynmanHome` is idempotent (calling twice doesn't throw)

- **`tests/catalog-snapshot.test.ts`** (new): Adds edge-case tests for `buildModelStatusSnapshotFromRecords` in `src/model/catalog.ts` not covered by `model-harness.test.ts`:
  - Empty guidance when model is valid and set
  - Guidance emitted when no models are available
  - Guidance emitted when no default model is set
  - Provider `configured` flag set only for providers with available models
  - Provider `current` flag set based on the active model's provider prefix
  - Available models sorted by research preference (Anthropic Opus > OpenAI)
  - `currentValid=false` when configured model is absent from the available list

## Test plan

- [ ] `node --import tsx --test tests/config-paths.test.ts` — all 9 tests pass locally
- [ ] `npm test` passes in CI (catalog tests require installed dependencies like `model-harness.test.ts` does)