### PR TITLE
fix: prevent npm package reinstall on every launch (nvm systems)

### DIFF
--- a/scripts/patch-embedded-pi.mjs
+++ b/scripts/patch-embedded-pi.mjs
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
+import { homedir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { FEYNMAN_LOGO_HTML } from "../logo.mjs";
@@ -9,6 +10,14 @@ import { PI_SUBAGENTS_PATCH_TARGETS, patchPiSubagentsSource } from "./lib/pi-sub
 
 const here = dirname(fileURLToPath(import.meta.url));
 const appRoot = resolve(here, "..");
+
+// Set npm global prefix early to ensure all npm commands use the correct path.
+const feynmanHome = resolve(process.env.FEYNMAN_HOME ?? homedir(), ".feynman");
+const feynmanNpmPrefix = resolve(feynmanHome, "npm-global");
+process.env.FEYNMAN_NPM_PREFIX = feynmanNpmPrefix;
+process.env.NPM_CONFIG_PREFIX = feynmanNpmPrefix;
+process.env.npm_config_prefix = feynmanNpmPrefix;
+
 const appRequire = createRequire(resolve(appRoot, "package.json"));
 const isGlobalInstall = process.env.npm_config_global === "true" || process.env.npm_config_location === "global";
 
@@ -76,7 +85,17 @@ const workspaceArchivePath = resolve(appRoot, ".feynman", "runtime-workspace.tgz
 function createInstallCommand(packageManager, packageSpecs) {
 	switch (packageManager) {
 		case "npm":
-			return ["install", "--prefer-offline", "--no-audit", "--no-fund", "--loglevel", "error", ...packageSpecs];
+			return [
+				"install",
+				"--global=false",
+				"--location=project",
+				"--prefer-offline",
+				"--no-audit",
+				"--no-fund",
+				"--loglevel",
+				"error",
+				...packageSpecs,
+			];
 		case "pnpm":
 			return ["add", "--prefer-offline", "--reporter", "silent", ...packageSpecs];
 		case "bun":


### PR DESCRIPTION
**Summary:**
- Fix npm packages reinstalling on every startup on Linux/WSL systems with nvm

**Problem:**
On systems using `nvm`, `npm root -g` returns the nvm path (e.g., `~/.nvm/versions/node/v22.x.x/lib/node_modules`) instead of Feynman’s path (`~/.feynman/npm-global/lib/node_modules`). This caused the package manager to think packages were not installed, triggering a full reinstall on every startup (~2–3 min delay).

**Fix:**
Set `NPM_CONFIG_PREFIX` at the very start of `patch-embedded-pi.mjs`, before any npm commands run. This ensures `npm root -g` resolves to the correct path.

**Test Plan**:
- Run Feynman on a system with `nvm`  
- Verify packages are not reinstalled on subsequent launches  
- Verify `FEYNMAN_HOME` override still works  

**Fixes**: Closes #25 