### PR TITLE
Document subagent model overrides

### DIFF
--- a/website/src/content/docs/getting-started/configuration.md
+++ b/website/src/content/docs/getting-started/configuration.md
@@ -41,6 +41,21 @@ To see all models you have configured:
 feynman model list
 ```
 
+## Subagent model overrides
+
+Feynman's bundled subagents inherit the main default model unless you override them explicitly. Inside the REPL, run:
+
+```bash
+/feynman-model
+```
+
+This opens an interactive picker where you can either:
+
+- change the **main (default)** model for the whole session environment, or
+- assign a different model to a specific bundled subagent such as `researcher`, `reviewer`, `writer`, or `verifier`
+
+Per-subagent overrides are persisted in the synced agent files under `~/.feynman/agent/agents/` by adding a `model:` frontmatter field. Removing that field makes the subagent inherit the main default model again.
+
 ## Thinking levels
 
 The `thinkingLevel` field controls how much reasoning the model does before responding. Available levels are `off`, `minimal`, `low`, `medium`, `high`, and `xhigh`. Higher levels produce more thorough analysis at the cost of latency and token usage. You can override per-session:

--- a/website/src/content/docs/reference/slash-commands.md
+++ b/website/src/content/docs/reference/slash-commands.md
@@ -30,12 +30,15 @@ These are the primary commands you will use day-to-day. Each workflow dispatches
 | `/log` | Write a durable session log with completed work, findings, open questions, and next steps |
 | `/jobs` | Inspect active background work: running processes, scheduled follow-ups, and active watches |
 | `/help` | Show grouped Feynman commands and prefill the editor with a selected command |
+| `/feynman-model` | Open the model picker for the main default model and per-subagent overrides |
 | `/init` | Bootstrap `AGENTS.md` and session-log folders for a new research project |
 | `/outputs` | Browse all research artifacts (papers, outputs, experiments, notes) |
 | `/search` | Search prior session transcripts for past research and findings |
 | `/preview` | Preview the current artifact as rendered HTML or PDF |
 
 Session management commands help you organize ongoing work. The `/log` command is particularly useful at the end of a research session to capture what was accomplished and what remains.
+
+The `/feynman-model` command opens an interactive picker that lets you either change the main default model or assign a different model to a specific bundled subagent like `researcher`, `reviewer`, `writer`, or `verifier`.
 
 ## Running workflows from the CLI
 


### PR DESCRIPTION
## Summary
- add `/feynman-model` to the static slash command reference so the shipped REPL command is discoverable outside the live help menu
- document that bundled subagents inherit the main default model unless a per-agent override is set through `/feynman-model`
- explain that per-subagent overrides persist via `model:` frontmatter in the synced agent markdown files

## Validation
- `npm test`
- `npm run typecheck`
- `npm run build`
- `npm run build` (in `website/`)
- `npm run typecheck` (in `website/`)
