### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/src/model/catalog.ts
+++ b/src/model/catalog.ts
@@ -99,6 +99,14 @@ const RESEARCH_MODEL_PREFERENCES = [
 		spec: "kimi-coding/kimi-k2-thinking",
 		reason: "good fallback when Kimi is the available research model",
 	},
+	{
+		spec: "minimax/MiniMax-M2.7",
+		reason: "good fallback when MiniMax is the available research model",
+	},
+	{
+		spec: "minimax/MiniMax-M2.7-highspeed",
+		reason: "faster MiniMax option when speed is prioritized for research tasks",
+	},
 ];
 
 const PROVIDER_SORT_ORDER = [

--- a/tests/model-harness.test.ts
+++ b/tests/model-harness.test.ts
@@ -66,3 +66,29 @@ test("resolveInitialPrompt maps top-level research commands to Pi slash workflow
 	assert.equal(resolveInitialPrompt("unknown", ["topic"], undefined, workflows), "unknown topic");
 });
 
+test("chooseRecommendedModel recommends MiniMax-M2.7 when only MiniMax is authenticated", () => {
+	const authPath = createAuthPath({
+		minimax: { type: "api_key", key: "minimax-test-key" },
+	});
+
+	const recommendation = chooseRecommendedModel(authPath);
+
+	assert.equal(recommendation?.spec, "minimax/MiniMax-M2.7");
+});
+
+test("buildModelStatusSnapshotFromRecords recommends minimax/MiniMax-M2.7 over minimax/MiniMax-M2.7-highspeed", () => {
+	const snapshot = buildModelStatusSnapshotFromRecords(
+		[
+			{ provider: "minimax", id: "MiniMax-M2.7" },
+			{ provider: "minimax", id: "MiniMax-M2.7-highspeed" },
+		],
+		[
+			{ provider: "minimax", id: "MiniMax-M2.7" },
+			{ provider: "minimax", id: "MiniMax-M2.7-highspeed" },
+		],
+		undefined,
+	);
+
+	assert.equal(snapshot.recommended, "minimax/MiniMax-M2.7");
+});
+


### PR DESCRIPTION
## Summary

- Add `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` to `RESEARCH_MODEL_PREFERENCES` in `src/model/catalog.ts`, enabling Feynman to recommend MiniMax models when users authenticate with a MiniMax API key
- MiniMax provider infrastructure (auth setup, API key env var `MINIMAX_API_KEY`, model registry) was already in place via `@mariozechner/pi-coding-agent`; this PR wires it into the research model recommendation system
- Add unit tests verifying that `chooseRecommendedModel` returns `minimax/MiniMax-M2.7` when only MiniMax is authenticated, and that `MiniMax-M2.7` is preferred over `MiniMax-M2.7-highspeed`

## API Reference

- Chat (Anthropic Compatible): https://platform.minimax.io/docs/api-reference/text-anthropic-api

## Test plan

- [x] `npm test` — new tests (8, 9) pass; only pre-existing test 5 failure (unrelated `gpt-5.4` model ID)
- [x] `npm run build` — TypeScript compilation succeeds with no errors
- [x] Integration: `MINIMAX_API_KEY` env var picked up by Pi model registry for `minimax` provider
