### PR TITLE
fix(pi): use file URLs for Node --import on Windows

### DIFF
--- a/src/pi/launch.ts
+++ b/src/pi/launch.ts
@@ -1,8 +1,13 @@
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 
 import { buildPiArgs, buildPiEnv, type PiRuntimeOptions, resolvePiPaths } from "./runtime.js";
 import { ensureSupportedNodeVersion } from "../system/node-version.js";
+
+export function toNodeImportSpecifier(modulePath: string): string {
+	return pathToFileURL(modulePath).href;
+}
 
 export async function launchPiChat(options: PiRuntimeOptions): Promise<void> {
 	ensureSupportedNodeVersion();
@@ -23,8 +28,8 @@ export async function launchPiChat(options: PiRuntimeOptions): Promise<void> {
 	}
 
 	const importArgs = useDevPolyfill
-		? ["--import", tsxLoaderPath, "--import", promisePolyfillSourcePath]
-		: ["--import", promisePolyfillPath];
+		? ["--import", toNodeImportSpecifier(tsxLoaderPath), "--import", toNodeImportSpecifier(promisePolyfillSourcePath)]
+		: ["--import", toNodeImportSpecifier(promisePolyfillPath)];
 
 	const child = spawn(process.execPath, [...importArgs, piCliPath, ...buildPiArgs(options)], {
 		cwd: options.workingDir,

--- a/tests/pi-launch.test.ts
+++ b/tests/pi-launch.test.ts
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { pathToFileURL } from "node:url";
+import { resolve } from "node:path";
+
+import { toNodeImportSpecifier } from "../src/pi/launch.js";
+
+test(
+	"toNodeImportSpecifier converts Windows absolute paths into file URLs",
+	{ skip: process.platform !== "win32" ? "Windows path assertion only applies on win32" : false },
+	() => {
+		assert.equal(
+			toNodeImportSpecifier("C:\\repo\\feynman\\dist\\system\\promise-polyfill.js"),
+			"file:///C:/repo/feynman/dist/system/promise-polyfill.js",
+		);
+	},
+);
+
+test("toNodeImportSpecifier matches Node's URL encoding for import targets", () => {
+	const modulePath = resolve("/repo/feynman", "dist", "system", "promise polyfill.js");
+
+	assert.equal(toNodeImportSpecifier(modulePath), pathToFileURL(modulePath).href);
+});

--- a/tests/pi-runtime.test.ts
+++ b/tests/pi-runtime.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { delimiter, resolve } from "node:path";
 
 import { applyFeynmanPackageManagerEnv, buildPiArgs, buildPiEnv, resolvePiPaths } from "../src/pi/runtime.js";
 
@@ -18,9 +19,9 @@ test("buildPiArgs includes configured runtime paths and prompt", () => {
 		"--session-dir",
 		"/sessions",
 		"--extension",
-		"/repo/feynman/extensions/research-tools.ts",
+		resolve("/repo/feynman", "extensions", "research-tools.ts"),
 		"--prompt-template",
-		"/repo/feynman/prompts",
+		resolve("/repo/feynman", "prompts"),
 		"--model",
 		"openai:gpt-5.4",
 		"--thinking",
@@ -45,15 +46,19 @@ test("buildPiEnv wires Feynman paths into the Pi environment", () => {
 
 	try {
 		assert.equal(env.FEYNMAN_SESSION_DIR, "/sessions");
-		assert.equal(env.FEYNMAN_BIN_PATH, "/repo/feynman/bin/feynman.js");
-		assert.equal(env.FEYNMAN_MEMORY_DIR, "/home/.feynman/memory");
-		assert.equal(env.FEYNMAN_NPM_PREFIX, "/home/.feynman/npm-global");
-		assert.equal(env.NPM_CONFIG_PREFIX, "/home/.feynman/npm-global");
-		assert.equal(env.npm_config_prefix, "/home/.feynman/npm-global");
+		assert.equal(env.FEYNMAN_BIN_PATH, resolve("/repo/feynman", "bin", "feynman.js"));
+		assert.equal(env.FEYNMAN_MEMORY_DIR, resolve("/home/.feynman", "memory"));
+		assert.equal(env.FEYNMAN_NPM_PREFIX, resolve("/home/.feynman", "npm-global"));
+		assert.equal(env.NPM_CONFIG_PREFIX, resolve("/home/.feynman", "npm-global"));
+		assert.equal(env.npm_config_prefix, resolve("/home/.feynman", "npm-global"));
 		assert.equal(env.PI_CODING_AGENT_DIR, "/home/.feynman/agent");
 		assert.ok(
 			env.PATH?.startsWith(
-				"/repo/feynman/node_modules/.bin:/repo/feynman/.feynman/npm/node_modules/.bin:/home/.feynman/npm-global/bin:",
+				[
+					resolve("/repo/feynman", "node_modules", ".bin"),
+					resolve("/repo/feynman", ".feynman", "npm", "node_modules", ".bin"),
+					resolve("/home/.feynman", "npm-global", "bin"),
+				].join(delimiter) + delimiter,
 			),
 		);
 	} finally {
@@ -78,10 +83,10 @@ test("applyFeynmanPackageManagerEnv pins npm globals to the Feynman prefix", () 
 	try {
 		const prefix = applyFeynmanPackageManagerEnv("/home/.feynman/agent");
 
-		assert.equal(prefix, "/home/.feynman/npm-global");
-		assert.equal(process.env.FEYNMAN_NPM_PREFIX, "/home/.feynman/npm-global");
-		assert.equal(process.env.NPM_CONFIG_PREFIX, "/home/.feynman/npm-global");
-		assert.equal(process.env.npm_config_prefix, "/home/.feynman/npm-global");
+		assert.equal(prefix, resolve("/home/.feynman", "npm-global"));
+		assert.equal(process.env.FEYNMAN_NPM_PREFIX, resolve("/home/.feynman", "npm-global"));
+		assert.equal(process.env.NPM_CONFIG_PREFIX, resolve("/home/.feynman", "npm-global"));
+		assert.equal(process.env.npm_config_prefix, resolve("/home/.feynman", "npm-global"));
 	} finally {
 		if (previousFeynmanPrefix === undefined) {
 			delete process.env.FEYNMAN_NPM_PREFIX;
@@ -104,5 +109,5 @@ test("applyFeynmanPackageManagerEnv pins npm globals to the Feynman prefix", () 
 test("resolvePiPaths includes the Promise.withResolvers polyfill path", () => {
 	const paths = resolvePiPaths("/repo/feynman");
 
-	assert.equal(paths.promisePolyfillPath, "/repo/feynman/dist/system/promise-polyfill.js");
+	assert.equal(paths.promisePolyfillPath, resolve("/repo/feynman", "dist", "system", "promise-polyfill.js"));
 });


### PR DESCRIPTION
**Summary**

Fix Windows startup failures caused by Node ESM rejecting `--import` paths like `C:\...` with `ERR_UNSUPPORTED_ESM_URL_SCHEME`.

**Problem**

On Windows, `launchPiChat` passed absolute file paths directly to `node --import`. Node’s ESM loader requires `file://` URL specifiers, so paths like `C:\...` were rejected.

This caused:
- Runtime failure with `ERR_UNSUPPORTED_ESM_URL_SCHEME: Received protocol 'c:'`  
- Pi runtime failing to launch on Windows  

**Fix**

- Update `src/pi/launch.ts`:
  - Add `toNodeImportSpecifier()` using `pathToFileURL(...).href`
  - Convert all `--import` arguments to proper `file://` URL specifiers (both built and dev paths)

- Add `tests/pi-launch.test.ts`:
  - Validate Windows path conversion to `file:///C:/...`
  - Ensure parity with `pathToFileURL()` encoding

- Update `tests/pi-runtime.test.ts`:
  - Use `resolve()` and `delimiter` for cross-platform compatibility

**Tradeoffs / Follow-up**

- Relies on Node’s `pathToFileURL` behavior for correctness across platforms  
- Future runtime flags or loaders should follow the same URL-based pattern  

**Test Plan**

- `npm test` passes  
- `npm run build` succeeds  
- Manual Windows validation confirms Pi runtime launches correctly  

**Fixes**: Closes #34