### PR TITLE
feat: Bedrock integration, CJK display fix, experiment integrity rules

### DIFF
--- a/.cursor/rules/agent-behavior.mdc
+++ b/.cursor/rules/agent-behavior.mdc
@@ -1,0 +1,19 @@
+---
+description: Agent behavior rules for this workspace
+alwaysApply: true
+---
+
+# Agent Behavior
+
+- All environment setup, dependency installation, service startup, and configuration tasks must be done directly by the agent. Never output commands and ask the user to run them manually.
+- When a service (e.g. bedrock-proxy) needs to be running, start it automatically before proceeding.
+- When dependencies are missing, install them directly.
+- When config files need changes, edit them directly.
+
+# Network Proxy
+
+- Local proxy address: `127.0.0.1:7890`. This is permanent. Never ask the user about it.
+- For ALL shell commands that access the network (git, gh, curl, npm, pip, etc.), always set:
+  `export http_proxy=http://127.0.0.1:7890 https_proxy=http://127.0.0.1:7890 HTTP_PROXY=http://127.0.0.1:7890 HTTPS_PROXY=http://127.0.0.1:7890`
+- For local services (localhost, 127.0.0.1), additionally set `NO_PROXY=localhost,127.0.0.1` to bypass the proxy.
+- Do not ask whether proxy is needed. Always use it by default for external network access.

--- a/.cursor/rules/bedrock-proxy.mdc
+++ b/.cursor/rules/bedrock-proxy.mdc
@@ -1,0 +1,16 @@
+---
+description: Bedrock proxy startup and configuration
+globs: scripts/bedrock-proxy.py
+alwaysApply: false
+---
+
+# Bedrock Proxy
+
+Feynman uses a local proxy (`scripts/bedrock-proxy.py`) to connect to AWS Bedrock.
+
+- The proxy must be running on port 4000 before Feynman can use any model.
+- Start command: `python3 -u scripts/bedrock-proxy.py --port 4000`
+- The proxy converts OpenAI-compatible API calls to Bedrock Converse API calls with proper inference profile ARNs.
+- AWS credentials live in `~/.aws/credentials` (region: us-east-1).
+- Network proxy: 127.0.0.1:7890 (configured in the script).
+- Feynman model config: `~/.feynman/agent/models.json` (provider: amazon-bedrock, pointing to localhost:4000).

--- a/.feynman/SYSTEM.md
+++ b/.feynman/SYSTEM.md
@@ -27,6 +27,16 @@ Operating rules:
 - When a task involves calculations, code, or quantitative outputs, define the minimal test or oracle set before implementation and record the results of those checks before delivery.
 - If a plot, number, or conclusion looks cleaner than expected, assume it may be wrong until it survives explicit checks. Never smooth curves, drop inconvenient variations, or tune presentation-only outputs without stating that choice.
 - When a verification pass finds one issue, continue searching for others. Do not stop after the first error unless the whole branch is blocked.
+
+Experimental integrity:
+- Never write experiment code that hardcodes, leaks, or presupposes the correct answer. If you are testing whether mechanism X selects the right gene, you may not pass the right gene as a hint to X -- that is circular. The experiment must let X discover the answer from its own logic.
+- Synthetic experiments must state every simplifying assumption and fixed probability up front in the code comments AND in the written report. Readers must be able to see exactly what was simulated and what was assumed.
+- Subjective or qualitative assessments (architecture comparisons, feature checklists, capability ratings) are not experiments. Never present hardcoded scores as empirical data. Label them clearly as "qualitative assessment" or "architectural analysis", not "Experiment N".
+- When comparing your own system against baselines, the baseline must be given a fair chance. A random baseline is not a meaningful comparison for a system that uses pattern matching. Use the strongest available baseline or justify why it is unavailable.
+- Every experiment script must be independently auditable: a reader who only has the code and its dependencies must be able to verify what the code actually tests, without reading the accompanying prose. If the code does not match the prose claims, the code is the ground truth.
+- Before delivering experiment results, run the reviewer or verifier subagent in adversarial-audit mode against the experiment code itself -- not just the prose. The audit must check for circular logic, rigged baselines, hardcoded outcomes, and assumptions that guarantee the conclusion.
+- If an experiment cannot be run against real systems (e.g., no API access to a competitor), say so explicitly. Do not substitute a simulation that assumes the competitor is worse and call it a "comparison".
+- Token cost, accuracy, or performance numbers from synthetic simulations must include the word "simulated" every time they appear in the report. They are not empirical benchmarks.
 - Use the visualization packages when a chart, diagram, or interactive widget would materially improve understanding. Prefer charts for quantitative comparisons, Mermaid for simple process/architecture diagrams, and interactive HTML widgets for exploratory visual explanations.
 - Persistent memory is package-backed. Use `memory_search` to recall prior preferences and lessons, `memory_remember` to store explicit durable facts, and `memory_lessons` when prior corrections matter.
 - If the user says "remember", states a stable preference, or asks for something to be the default in future sessions, call `memory_remember`. Do not just say you will remember it.

--- a/.feynman/agents/reviewer.md
+++ b/.feynman/agents/reviewer.md
@@ -28,6 +28,11 @@ If the parent frames the task as a verification pass rather than a venue-style p
   - sections, figures, or tables that appear to survive from earlier drafts without support
   - notation drift, inconsistent terminology, or conclusions that use stronger language than the evidence warrants
   - "verified" or "confirmed" statements that do not actually show the check that was performed
+  - **circular experiment design** -- when the code feeds the expected answer into the system under test, making the hypothesis unfalsifiable
+  - **strawman baselines** -- when the comparison baseline is trivially weak (e.g., pure random) while stronger alternatives exist
+  - **qualitative scores dressed as data** -- when manually assigned ratings in source code are presented under "Experiment" headings as if they were measured
+  - **simulated results without disclosure** -- synthetic data or Monte Carlo results presented without the "simulated" label
+  - **unfalsifiable experiment design** -- any experiment where the structure of the code guarantees the desired outcome regardless of the system's actual behavior
 - Distinguish between fatal issues, strong concerns, and polish issues.
 - Preserve uncertainty. If the draft might pass depending on venue norms, say so explicitly.
 - Keep looking after you find the first major problem. Do not stop at one issue if others remain visible.
@@ -79,6 +84,16 @@ Quote specific passages from the paper and annotate them directly:
 ```
 
 Reference the weakness/question IDs from Part 1 so annotations link back to the structured review.
+
+## Experiment code review
+
+When the paper includes experiment scripts, you must read and audit the code:
+
+1. For each experiment script, trace the data flow from input to reported metric. Verify that the system under test is not given the answer it is supposed to discover.
+2. For each baseline, assess whether it is the strongest feasible alternative. Flag strawman baselines as **MAJOR** or **FATAL**.
+3. For horizontal comparisons, check whether competing systems were actually executed or just rated by the author. Manually assigned scores are opinion, not data.
+4. For simulated experiments, verify that all fixed probabilities, success rates, and cost models are documented and that the results are labeled "simulated" in the prose.
+5. Include a dedicated "Experiment Integrity" section in your review that lists each experiment and its audit verdict: `PASS`, `CONCERN: [reason]`, or `FAIL: [reason]`.
 
 ## Operating rules
 - Every weakness must reference a specific passage or section in the paper.

--- a/.feynman/agents/verifier.md
+++ b/.feynman/agents/verifier.md
@@ -39,6 +39,19 @@ For code-backed or quantitative claims:
 - If a figure, table, benchmark, or computed result lacks a traceable source or artifact path, weaken or remove the claim rather than guessing.
 - Do not preserve polished summaries that outrun the raw evidence.
 
+## Experiment code audit
+
+When the draft references experiment code or results from scripts, you must audit the code itself:
+
+1. **Read every experiment script referenced by the draft.** Do not trust prose descriptions of what the code does.
+2. **Check for circular logic.** If the code passes the expected correct answer as an input to the system under test (e.g., `preferredGeneId: scenario.bestGene`), flag it as **FATAL: circular experiment design**. The system must discover the answer, not receive it.
+3. **Check for rigged baselines.** If the primary comparison baseline is trivially weak (e.g., pure random when deterministic heuristics exist), flag it as **MAJOR: strawman baseline**.
+4. **Check for hardcoded qualitative scores.** If scores are manually assigned in source code and presented as experimental results, flag as **FATAL: qualitative data mislabeled as empirical**.
+5. **Check simulation assumptions.** If the experiment uses synthetic data with fixed probabilities, verify that the assumptions are documented in the prose and that results carry the "simulated" label.
+6. **Verify code-prose consistency.** If the prose claims "100% accuracy" but the code achieves this by design (not by learning), flag the discrepancy.
+
+For each issue found, include the filename, line numbers, and a concrete description of the problem. Do not approve a draft that contains FATAL experiment integrity issues.
+
 ## Output contract
 - Save to the output path specified by the parent (default: `cited.md`).
 - The output is the complete final document — same structure as the input draft, but with inline citations added throughout and a verified Sources section.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,17 @@ Never use generic names like `research.md`, `draft.md`, `brief.md`, or `summary.
 - For quantitative or code-backed outputs, keep raw artifact paths, scripts, or logs that support the final claim. Do not rely on polished summaries alone.
 - Never smooth over missing checks. Mark work as `blocked`, `unverified`, or `inferred` when that is the honest status.
 
+## Experimental code integrity
+
+These rules apply to all agents that produce or consume experiment code.
+
+- Experiment code is a first-class deliverable, not scaffolding. It must be auditable independently of the prose report.
+- The `verifier` or `reviewer` subagent must audit experiment source code before the lead agent delivers results. The audit checks for: circular logic (hardcoding the expected answer), rigged baselines, assumptions that guarantee the conclusion, and mislabeling of simulated data as empirical.
+- Qualitative framework comparisons with manually assigned scores are not experiments. They must be labeled as "qualitative architectural assessment" in both code and prose. They may not appear under headings like "Experiment N" or "Results".
+- Simulated results must carry the label "simulated" wherever they appear in final outputs. A reader must never mistake a synthetic run for a real-world benchmark.
+- When an experiment compares system A against baselines, the baselines must be the strongest feasible alternatives, not strawmen. Using pure random selection as the primary baseline when deterministic heuristics exist is not acceptable without explicit justification.
+- If an experiment's design makes it impossible for the hypothesis to fail (e.g., passing the correct answer as input and then measuring accuracy), the experiment is invalid and must not be delivered.
+
 ## Delegation rules
 
 - The lead agent plans, delegates, synthesizes, and delivers.

--- a/extensions/research-tools/header.ts
+++ b/extensions/research-tools/header.ts
@@ -4,7 +4,7 @@ import { execSync } from "node:child_process";
 import { resolve as resolvePath } from "node:path";
 
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import { visibleWidth, truncateToWidth } from "@mariozechner/pi-tui";
 
 import {
 	APP_ROOT,
@@ -12,18 +12,13 @@ import {
 	FEYNMAN_VERSION,
 } from "./shared.js";
 
-function visibleLength(text: string): number {
-	return visibleWidth(text);
-}
-
 function formatHeaderPath(path: string): string {
 	const home = homedir();
 	return path.startsWith(home) ? `~${path.slice(home.length)}` : path;
 }
 
 function truncateVisible(text: string, maxVisible: number): string {
-	if (visibleWidth(text) <= maxVisible) return text;
-	return truncateToWidth(text, maxVisible, maxVisible <= 3 ? "" : "...");
+	return truncateToWidth(text, maxVisible, "...");
 }
 
 function wrapWords(text: string, maxW: number): string[] {
@@ -33,7 +28,7 @@ function wrapWords(text: string, maxW: number): string[] {
 	for (let word of words) {
 		if (visibleWidth(word) > maxW) {
 			if (cur) { lines.push(cur); cur = ""; }
-			word = truncateToWidth(word, maxW, maxW > 3 ? "…" : "");
+			word = truncateToWidth(word, maxW, "...");
 		}
 		const test = cur ? `${cur} ${word}` : word;
 		if (cur && visibleWidth(test) > maxW) {
@@ -48,16 +43,8 @@ function wrapWords(text: string, maxW: number): string[] {
 }
 
 function padRight(text: string, width: number): string {
-	const gap = Math.max(0, width - visibleLength(text));
+	const gap = Math.max(0, width - visibleWidth(text));
 	return `${text}${" ".repeat(gap)}`;
-}
-
-function centerText(text: string, width: number): string {
-	const textWidth = visibleWidth(text);
-	if (textWidth >= width) return truncateToWidth(text, width, "");
-	const left = Math.floor((width - textWidth) / 2);
-	const right = width - textWidth - left;
-	return `${" ".repeat(left)}${text}${" ".repeat(right)}`;
 }
 
 function getCurrentModelLabel(ctx: ExtensionContext): string {
@@ -228,7 +215,7 @@ export function installFeynmanHeader(
 
 				push("");
 				if (cardW >= 70) {
-					const maxLogoW = Math.max(...FEYNMAN_AGENT_LOGO.map((l) => l.length));
+					const maxLogoW = Math.max(...FEYNMAN_AGENT_LOGO.map((l) => visibleWidth(l)));
 					const logoOffset = " ".repeat(Math.max(0, Math.floor((cardW - maxLogoW) / 2)));
 					for (const logoLine of FEYNMAN_AGENT_LOGO) {
 						push(theme.fg("accent", theme.bold(`${logoOffset}${truncateVisible(logoLine, cardW)}`)));
@@ -237,7 +224,7 @@ export function installFeynmanHeader(
 				}
 
 				const versionTag = ` v${FEYNMAN_VERSION} `;
-				const gap = Math.max(0, innerW - versionTag.length);
+				const gap = Math.max(0, innerW - visibleWidth(versionTag));
 				const gapL = Math.floor(gap / 2);
 				push(
 					border(`╭${"─".repeat(gapL)}`) +
@@ -308,7 +295,7 @@ export function installFeynmanHeader(
 						let first = true;
 						for (const word of descWords) {
 							const test = line ? `${line} ${word}` : word;
-							if (line && test.length > descW) {
+							if (line && visibleWidth(test) > descW) {
 								rightLines.push(
 									first
 										? `${theme.fg("accent", wf.name.padEnd(cmdNameW))}${theme.fg("dim", line)}`

--- a/scripts/bedrock-proxy.py
+++ b/scripts/bedrock-proxy.py
@@ -1,0 +1,554 @@
+"""
+Lightweight OpenAI-compatible proxy for AWS Bedrock Converse API.
+
+Translates /v1/chat/completions requests into Bedrock converse/converse_stream
+calls, using inference profile ARNs so on-demand models work correctly.
+
+Supports: text, tool definitions, tool_calls responses, tool result messages,
+streaming and non-streaming.
+
+Usage:
+    python3 scripts/bedrock-proxy.py [--port 4000]
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import uuid
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from socketserver import ThreadingMixIn
+
+os.environ.setdefault("HTTP_PROXY", "http://127.0.0.1:7890")
+os.environ.setdefault("HTTPS_PROXY", "http://127.0.0.1:7890")
+os.environ.setdefault("http_proxy", "http://127.0.0.1:7890")
+os.environ.setdefault("https_proxy", "http://127.0.0.1:7890")
+
+import boto3
+from botocore.config import Config as BotoConfig
+
+REGION = "us-east-1"
+ACCOUNT_ID = "493919098970"
+
+MODEL_ALIASES = {
+    "claude-opus-4-6": "us.anthropic.claude-opus-4-6-v1",
+    "claude-sonnet-4-6": "us.anthropic.claude-sonnet-4-6",
+    "claude-sonnet-4-5": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "claude-opus-4-5": "us.anthropic.claude-opus-4-5-20251101-v1:0",
+    "claude-opus-4-1": "us.anthropic.claude-opus-4-1-20250805-v1:0",
+    "claude-opus-4": "us.anthropic.claude-opus-4-20250514-v1:0",
+    "claude-sonnet-4": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+    "claude-haiku-4-5": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "claude-3-7-sonnet": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+    "claude-3-5-haiku": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+}
+
+
+def resolve_model_id(model_input: str) -> str:
+    cleaned = model_input.removeprefix("bedrock/").removeprefix("converse/")
+    if cleaned in MODEL_ALIASES:
+        cleaned = MODEL_ALIASES[cleaned]
+    if cleaned.startswith("arn:"):
+        return cleaned
+    if cleaned.startswith("us.") or cleaned.startswith("global."):
+        return (
+            f"arn:aws:bedrock:{REGION}:{ACCOUNT_ID}:"
+            f"inference-profile/{cleaned}"
+        )
+    if cleaned.startswith("anthropic.") or cleaned.startswith("amazon."):
+        return (
+            f"arn:aws:bedrock:{REGION}:{ACCOUNT_ID}:"
+            f"inference-profile/us.{cleaned}"
+        )
+    return (
+        f"arn:aws:bedrock:{REGION}:{ACCOUNT_ID}:"
+        f"inference-profile/{cleaned}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# OpenAI tools -> Bedrock toolConfig
+# ---------------------------------------------------------------------------
+
+def openai_tools_to_bedrock(tools: list | None) -> dict | None:
+    if not tools:
+        return None
+    bedrock_tools = []
+    for tool in tools:
+        if tool.get("type") != "function":
+            continue
+        fn = tool.get("function", {})
+        spec = {
+            "name": fn.get("name", ""),
+            "description": fn.get("description", ""),
+        }
+        params = fn.get("parameters")
+        if params:
+            spec["inputSchema"] = {"json": params}
+        bedrock_tools.append({"toolSpec": spec})
+    if not bedrock_tools:
+        return None
+    return {"tools": bedrock_tools}
+
+
+# ---------------------------------------------------------------------------
+# OpenAI messages -> Bedrock messages
+# ---------------------------------------------------------------------------
+
+def openai_messages_to_bedrock(messages: list) -> tuple[list, list | None]:
+    system_prompts = []
+    converse_messages = []
+    for msg in messages:
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+
+        if role == "system":
+            if isinstance(content, str) and content:
+                system_prompts.append({"text": content})
+            continue
+
+        if role == "tool":
+            tool_call_id = msg.get("tool_call_id", "")
+            result_content = content if isinstance(content, str) else json.dumps(content)
+            converse_messages.append({
+                "role": "user",
+                "content": [{
+                    "toolResult": {
+                        "toolUseId": tool_call_id,
+                        "content": [{"text": result_content}],
+                    }
+                }],
+            })
+            continue
+
+        if role == "assistant":
+            blocks = []
+            if isinstance(content, str) and content:
+                blocks.append({"text": content})
+            elif isinstance(content, list):
+                for item in content:
+                    if isinstance(item, str):
+                        blocks.append({"text": item})
+                    elif isinstance(item, dict) and item.get("type") == "text":
+                        blocks.append({"text": item.get("text", "")})
+
+            tool_calls = msg.get("tool_calls", [])
+            for tc in tool_calls:
+                fn = tc.get("function", {})
+                args_str = fn.get("arguments", "{}")
+                try:
+                    args_obj = json.loads(args_str)
+                except (json.JSONDecodeError, TypeError):
+                    args_obj = {}
+                blocks.append({
+                    "toolUse": {
+                        "toolUseId": tc.get("id", f"tool_{uuid.uuid4().hex[:8]}"),
+                        "name": fn.get("name", ""),
+                        "input": args_obj,
+                    }
+                })
+
+            if blocks:
+                converse_messages.append({"role": "assistant", "content": blocks})
+            continue
+
+        # user role
+        if isinstance(content, str):
+            converse_messages.append(
+                {"role": "user", "content": [{"text": content or " "}]}
+            )
+        elif isinstance(content, list):
+            parts = []
+            for item in content:
+                if isinstance(item, str):
+                    parts.append({"text": item})
+                elif isinstance(item, dict) and item.get("type") == "text":
+                    parts.append({"text": item.get("text", "")})
+            if parts:
+                converse_messages.append({"role": "user", "content": parts})
+
+    # Bedrock requires alternating user/assistant. Merge consecutive same-role.
+    merged = _merge_consecutive_roles(converse_messages)
+    return merged, system_prompts or None
+
+
+def _merge_consecutive_roles(messages: list) -> list:
+    if not messages:
+        return messages
+    merged = [messages[0]]
+    for msg in messages[1:]:
+        if msg["role"] == merged[-1]["role"]:
+            merged[-1]["content"].extend(msg["content"])
+        else:
+            merged.append(msg)
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Bedrock response -> OpenAI response (non-streaming)
+# ---------------------------------------------------------------------------
+
+def bedrock_to_openai_response(result: dict, model: str) -> dict:
+    output = result.get("output", {})
+    message = output.get("message", {})
+    content_blocks = message.get("content", [])
+
+    text_parts = [b["text"] for b in content_blocks if "text" in b]
+    text = "".join(text_parts) or None
+
+    tool_calls = []
+    for block in content_blocks:
+        if "toolUse" in block:
+            tu = block["toolUse"]
+            tool_calls.append({
+                "id": tu.get("toolUseId", f"call_{uuid.uuid4().hex[:8]}"),
+                "type": "function",
+                "function": {
+                    "name": tu.get("name", ""),
+                    "arguments": json.dumps(tu.get("input", {})),
+                },
+            })
+
+    stop_reason = result.get("stopReason", "end_turn")
+    usage = result.get("usage", {})
+
+    oai_message = {"role": "assistant", "content": text}
+    if tool_calls:
+        oai_message["tool_calls"] = tool_calls
+
+    return {
+        "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": oai_message,
+                "finish_reason": _map_stop_reason(stop_reason),
+            }
+        ],
+        "usage": {
+            "prompt_tokens": usage.get("inputTokens", 0),
+            "completion_tokens": usage.get("outputTokens", 0),
+            "total_tokens": usage.get("inputTokens", 0)
+            + usage.get("outputTokens", 0),
+        },
+    }
+
+
+def _map_stop_reason(reason: str) -> str:
+    mapping = {
+        "end_turn": "stop",
+        "max_tokens": "length",
+        "stop_sequence": "stop",
+        "tool_use": "tool_calls",
+        "content_filtered": "content_filter",
+    }
+    return mapping.get(reason, "stop")
+
+
+# ---------------------------------------------------------------------------
+# Bedrock stream -> OpenAI SSE chunks (with tool call support)
+# ---------------------------------------------------------------------------
+
+def stream_bedrock_to_openai(response_stream, model: str):
+    chunk_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
+
+    first_chunk = {
+        "id": chunk_id,
+        "object": "chat.completion.chunk",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"role": "assistant", "content": ""},
+                "finish_reason": None,
+            }
+        ],
+    }
+    yield f"data: {json.dumps(first_chunk)}\n\n"
+
+    # Track tool use blocks by their content block index
+    tool_index_map = {}  # bedrock contentBlockIndex -> openai tool_calls array index
+    next_tool_index = 0
+
+    for event in response_stream.get("stream", []):
+        if "contentBlockStart" in event:
+            start = event["contentBlockStart"]
+            block_idx = start.get("contentBlockIndex", 0)
+            if "toolUse" in start.get("start", {}):
+                tu = start["start"]["toolUse"]
+                tool_idx = next_tool_index
+                tool_index_map[block_idx] = tool_idx
+                next_tool_index += 1
+                chunk = {
+                    "id": chunk_id,
+                    "object": "chat.completion.chunk",
+                    "created": int(time.time()),
+                    "model": model,
+                    "choices": [{
+                        "index": 0,
+                        "delta": {
+                            "tool_calls": [{
+                                "index": tool_idx,
+                                "id": tu.get("toolUseId", f"call_{uuid.uuid4().hex[:8]}"),
+                                "type": "function",
+                                "function": {
+                                    "name": tu.get("name", ""),
+                                    "arguments": "",
+                                },
+                            }],
+                        },
+                        "finish_reason": None,
+                    }],
+                }
+                yield f"data: {json.dumps(chunk)}\n\n"
+
+        elif "contentBlockDelta" in event:
+            cbd = event["contentBlockDelta"]
+            block_idx = cbd.get("contentBlockIndex", 0)
+            delta = cbd.get("delta", {})
+
+            if "text" in delta and delta["text"]:
+                chunk = {
+                    "id": chunk_id,
+                    "object": "chat.completion.chunk",
+                    "created": int(time.time()),
+                    "model": model,
+                    "choices": [{
+                        "index": 0,
+                        "delta": {"content": delta["text"]},
+                        "finish_reason": None,
+                    }],
+                }
+                yield f"data: {json.dumps(chunk)}\n\n"
+
+            elif "toolUse" in delta:
+                input_chunk = delta["toolUse"].get("input", "")
+                tool_idx = tool_index_map.get(block_idx, 0)
+                chunk = {
+                    "id": chunk_id,
+                    "object": "chat.completion.chunk",
+                    "created": int(time.time()),
+                    "model": model,
+                    "choices": [{
+                        "index": 0,
+                        "delta": {
+                            "tool_calls": [{
+                                "index": tool_idx,
+                                "function": {
+                                    "arguments": input_chunk,
+                                },
+                            }],
+                        },
+                        "finish_reason": None,
+                    }],
+                }
+                yield f"data: {json.dumps(chunk)}\n\n"
+
+        elif "messageStop" in event:
+            stop_reason = event["messageStop"].get("stopReason", "end_turn")
+            chunk = {
+                "id": chunk_id,
+                "object": "chat.completion.chunk",
+                "created": int(time.time()),
+                "model": model,
+                "choices": [{
+                    "index": 0,
+                    "delta": {},
+                    "finish_reason": _map_stop_reason(stop_reason),
+                }],
+            }
+            yield f"data: {json.dumps(chunk)}\n\n"
+
+        elif "metadata" in event:
+            usage = event["metadata"].get("usage", {})
+            if usage:
+                usage_chunk = {
+                    "id": chunk_id,
+                    "object": "chat.completion.chunk",
+                    "created": int(time.time()),
+                    "model": model,
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": usage.get("inputTokens", 0),
+                        "completion_tokens": usage.get("outputTokens", 0),
+                        "total_tokens": usage.get("inputTokens", 0)
+                        + usage.get("outputTokens", 0),
+                    },
+                }
+                yield f"data: {json.dumps(usage_chunk)}\n\n"
+
+    yield "data: [DONE]\n\n"
+
+
+# ---------------------------------------------------------------------------
+# HTTP server
+# ---------------------------------------------------------------------------
+
+class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
+    daemon_threads = True
+
+
+class BedrockProxyHandler(BaseHTTPRequestHandler):
+    client = None
+
+    def setup(self):
+        super().setup()
+        self.wfile = self.request.makefile("wb", 0)
+
+    def log_message(self, format, *args):
+        print(f"[bedrock-proxy] {args[0]}", file=sys.stderr, flush=True)
+
+    def do_GET(self):
+        if self.path == "/v1/models" or self.path == "/models":
+            models_data = {
+                "object": "list",
+                "data": [
+                    {
+                        "id": alias,
+                        "object": "model",
+                        "owned_by": "aws-bedrock",
+                    }
+                    for alias in MODEL_ALIASES
+                ],
+            }
+            self._json_response(200, models_data)
+            return
+
+        if self.path == "/health" or self.path == "/":
+            self._json_response(200, {"status": "ok"})
+            return
+
+        self._json_response(404, {"error": "not found"})
+
+    def do_POST(self):
+        if self.path not in (
+            "/v1/chat/completions",
+            "/chat/completions",
+        ):
+            self._json_response(404, {"error": "not found"})
+            return
+
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(content_length))
+
+        model_input = body.get("model", "claude-sonnet-4-6")
+        model_arn = resolve_model_id(model_input)
+        messages = body.get("messages", [])
+        stream = body.get("stream", False)
+        raw_max = body.get("max_tokens") or body.get("max_completion_tokens") or 16384
+        max_tokens = max(raw_max, 16384)
+        temperature = body.get("temperature")
+        top_p = body.get("top_p")
+        tools = body.get("tools")
+        tool_choice = body.get("tool_choice")
+        print(f"[bedrock-proxy] model={model_input} stream={stream} "
+              f"raw_max_tokens={raw_max} -> effective={max_tokens} "
+              f"tools={len(tools) if tools else 0}",
+              file=sys.stderr, flush=True)
+
+        converse_messages, system_prompts = openai_messages_to_bedrock(messages)
+
+        kwargs = {
+            "modelId": model_arn,
+            "messages": converse_messages,
+        }
+        if system_prompts:
+            kwargs["system"] = system_prompts
+
+        inference_config = {"maxTokens": max_tokens}
+        if temperature is not None:
+            inference_config["temperature"] = temperature
+        if top_p is not None:
+            inference_config["topP"] = top_p
+        kwargs["inferenceConfig"] = inference_config
+
+        tool_config = openai_tools_to_bedrock(tools)
+        if tool_config:
+            if tool_choice == "none":
+                tool_config["toolChoice"] = {"auto": {}}
+            elif tool_choice == "auto" or tool_choice is None:
+                tool_config["toolChoice"] = {"auto": {}}
+            elif tool_choice == "required":
+                tool_config["toolChoice"] = {"any": {}}
+            elif isinstance(tool_choice, dict) and tool_choice.get("type") == "function":
+                tool_config["toolChoice"] = {"tool": {"name": tool_choice["function"]["name"]}}
+            kwargs["toolConfig"] = tool_config
+
+        try:
+            if stream:
+                response = self.__class__.client.converse_stream(**kwargs)
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Cache-Control", "no-cache")
+                self.send_header("Connection", "close")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                for chunk_data in stream_bedrock_to_openai(
+                    response, model_input
+                ):
+                    self.wfile.write(chunk_data.encode())
+                    self.wfile.flush()
+                self.close_connection = True
+            else:
+                response = self.__class__.client.converse(**kwargs)
+                result = bedrock_to_openai_response(response, model_input)
+                self._json_response(200, result)
+
+        except Exception as e:
+            error_msg = str(e)
+            print(f"[bedrock-proxy] ERROR: {error_msg}", file=sys.stderr, flush=True)
+            self._json_response(
+                500, {"error": {"message": error_msg, "type": "server_error"}}
+            )
+
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "*")
+        self.end_headers()
+
+    def _json_response(self, status: int, data: dict):
+        body = json.dumps(data).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Bedrock OpenAI proxy")
+    parser.add_argument("--port", type=int, default=4000)
+    args = parser.parse_args()
+
+    BedrockProxyHandler.client = boto3.client(
+        "bedrock-runtime",
+        region_name=REGION,
+        config=BotoConfig(
+            read_timeout=600,
+            connect_timeout=10,
+            retries={"max_attempts": 2, "mode": "adaptive"},
+        ),
+    )
+
+    server = ThreadedHTTPServer(("0.0.0.0", args.port), BedrockProxyHandler)
+    print(f"[bedrock-proxy] Listening on http://0.0.0.0:{args.port}", file=sys.stderr, flush=True)
+    print(f"[bedrock-proxy] Available models: {', '.join(MODEL_ALIASES.keys())}", file=sys.stderr, flush=True)
+    print(f"[bedrock-proxy] OpenAI endpoint: http://localhost:{args.port}/v1/chat/completions", file=sys.stderr, flush=True)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\n[bedrock-proxy] Shutting down.", file=sys.stderr, flush=True)
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bedrock/proxy.ts
+++ b/src/bedrock/proxy.ts
@@ -1,0 +1,64 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { resolve } from "node:path";
+
+const PROXY_PORT = 4000;
+const PROXY_HEALTH_URL = `http://127.0.0.1:${PROXY_PORT}/health`;
+const STARTUP_TIMEOUT_MS = 15_000;
+const POLL_INTERVAL_MS = 300;
+
+let proxyProcess: ChildProcess | undefined;
+
+async function isProxyRunning(): Promise<boolean> {
+	try {
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), 2000);
+		const res = await fetch(PROXY_HEALTH_URL, { signal: controller.signal });
+		clearTimeout(timer);
+		return res.ok;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForProxy(): Promise<void> {
+	const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+	while (Date.now() < deadline) {
+		if (await isProxyRunning()) return;
+		await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+	}
+	throw new Error(`Bedrock proxy did not become healthy within ${STARTUP_TIMEOUT_MS / 1000}s on port ${PROXY_PORT}`);
+}
+
+export async function ensureBedrockProxy(appRoot: string): Promise<void> {
+	if (await isProxyRunning()) {
+		return;
+	}
+
+	const scriptPath = resolve(appRoot, "scripts", "bedrock-proxy.py");
+	const child = spawn("python3", ["-u", scriptPath, "--port", String(PROXY_PORT)], {
+		stdio: "ignore",
+		detached: false,
+		env: {
+			...process.env,
+			HTTP_PROXY: process.env.HTTP_PROXY ?? "http://127.0.0.1:7890",
+			HTTPS_PROXY: process.env.HTTPS_PROXY ?? "http://127.0.0.1:7890",
+			http_proxy: process.env.http_proxy ?? "http://127.0.0.1:7890",
+			https_proxy: process.env.https_proxy ?? "http://127.0.0.1:7890",
+			NO_PROXY: "localhost,127.0.0.1",
+			no_proxy: "localhost,127.0.0.1",
+		},
+	});
+
+	child.on("error", () => {});
+	child.unref();
+	proxyProcess = child;
+
+	await waitForProxy();
+}
+
+export function stopBedrockProxy(): void {
+	if (proxyProcess && !proxyProcess.killed) {
+		proxyProcess.kill();
+		proxyProcess = undefined;
+	}
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import {
 } from "@companion-ai/alpha-hub/lib";
 import { DefaultPackageManager, SettingsManager } from "@mariozechner/pi-coding-agent";
 
+import { ensureBedrockProxy, stopBedrockProxy } from "./bedrock/proxy.js";
 import { syncBundledAssets } from "./bootstrap/sync.js";
 import { ensureFeynmanHome, getDefaultSessionDir, getFeynmanAgentDir, getFeynmanHome } from "./config/paths.js";
 import { launchPiChat } from "./pi/launch.js";
@@ -493,15 +494,21 @@ export async function main(): Promise<void> {
 		normalizeFeynmanSettings(feynmanSettingsPath, bundledSettingsPath, thinkingLevel, feynmanAuthPath);
 	}
 
-	await launchPiChat({
-		appRoot,
-		workingDir,
-		sessionDir,
-		feynmanAgentDir,
-		feynmanVersion,
-		thinkingLevel,
-		explicitModelSpec,
-		oneShotPrompt: values.prompt,
-		initialPrompt: resolveInitialPrompt(command, rest, values.prompt, new Set(readPromptSpecs(appRoot).filter((s) => s.topLevelCli).map((s) => s.name))),
-	});
+	await ensureBedrockProxy(appRoot);
+
+	try {
+		await launchPiChat({
+			appRoot,
+			workingDir,
+			sessionDir,
+			feynmanAgentDir,
+			feynmanVersion,
+			thinkingLevel,
+			explicitModelSpec,
+			oneShotPrompt: values.prompt,
+			initialPrompt: resolveInitialPrompt(command, rest, values.prompt, new Set(readPromptSpecs(appRoot).filter((s) => s.topLevelCli).map((s) => s.name))),
+		});
+	} finally {
+		stopBedrockProxy();
+	}
 }


### PR DESCRIPTION
## Summary

- Add custom Bedrock proxy (`scripts/bedrock-proxy.py`) translating OpenAI API to Bedrock Converse API with inference profile ARNs, full tool calling, streaming usage reporting, and min max_tokens enforcement (16384 floor).
- Add `src/bedrock/proxy.ts` for automatic proxy lifecycle management; Feynman now starts/stops the proxy automatically on launch.
- Fix TUI crash on CJK paths by replacing custom width calculation with `pi-tui` `visibleWidth`/`truncateToWidth` in `header.ts`.
- Add experimental integrity rules to `SYSTEM.md`, `AGENTS.md`, `verifier.md`, and `reviewer.md` to prevent circular experiment design, strawman baselines, and mislabeled qualitative scores.
- Add Cursor workspace rules for agent behavior and network proxy.

## Changes

| Area | Files |
|------|-------|
| Bedrock proxy | `scripts/bedrock-proxy.py`, `src/bedrock/proxy.ts`, `src/cli.ts` |
| CJK display fix | `extensions/research-tools/header.ts` |
| Experiment integrity | `.feynman/SYSTEM.md`, `.feynman/agents/reviewer.md`, `.feynman/agents/verifier.md`, `AGENTS.md` |
| Workspace rules | `.cursor/rules/agent-behavior.mdc`, `.cursor/rules/bedrock-proxy.mdc` |

## Test plan

- [ ] Verify `bedrock-proxy.py` starts and responds on `/health`
- [ ] Confirm TUI header renders correctly with CJK characters in paths
- [ ] Validate that experiment integrity rules are applied by reviewer/verifier subagents