### PR TITLE
fix: Clarify standalone app upgrade docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,26 @@ The one-line installer fetches the latest tagged release. To pin a version, pass
 
 The installer downloads a standalone native bundle with its own Node.js runtime.
 
+### Updating
+
+To update the standalone Feynman app, rerun the installer for your platform:
+
+**macOS / Linux:**
+
+```bash
+curl -fsSL https://feynman.is/install | bash
+```
+
+**Windows (PowerShell):**
+
+```powershell
+irm https://feynman.is/install.ps1 | iex
+```
+
+That replaces the installed runtime with the latest tagged release. To upgrade to a specific version instead, pass the version explicitly to the installer.
+
+`feynman update` does **not** upgrade the standalone app itself. It updates the installed Pi packages inside your Feynman environment.
+
 Local models are supported through the custom-provider flow. For Ollama, run `feynman setup`, choose `Custom provider (baseUrl + API key)`, use `openai-completions`, and point it at `http://localhost:11434/v1`.
 
 ### Skills Only

--- a/website/src/content/docs/getting-started/installation.md
+++ b/website/src/content/docs/getting-started/installation.md
@@ -71,6 +71,26 @@ On Windows:
 & ([scriptblock]::Create((irm https://feynman.is/install.ps1))) -Version 0.2.17
 ```
 
+## Updating Feynman
+
+To upgrade the standalone Feynman app, rerun the installer for your platform. This refreshes the installed runtime bundle to the latest tagged release.
+
+On macOS or Linux:
+
+```bash
+curl -fsSL https://feynman.is/install | bash
+```
+
+On Windows:
+
+```powershell
+irm https://feynman.is/install.ps1 | iex
+```
+
+To upgrade to a specific release instead of the latest one, rerun the installer with an explicit version as shown above in [Pinned releases](#pinned-releases).
+
+The `feynman update` command is different: it updates installed Pi packages inside your Feynman environment. It does not replace the standalone Feynman runtime bundle itself.
+
 ## Post-install setup
 
 After installation, run the guided setup wizard to configure your model provider and API keys:

--- a/website/src/content/docs/reference/cli-commands.md
+++ b/website/src/content/docs/reference/cli-commands.md
@@ -45,9 +45,11 @@ AlphaXiv authentication enables Feynman to search and retrieve papers, access di
 | --- | --- |
 | `feynman packages list` | List all available packages and their install status |
 | `feynman packages install <preset>` | Install an optional package preset |
-| `feynman update [package]` | Update installed packages, or a specific package by name |
+| `feynman update [package]` | Update installed Pi packages, or a specific package by name |
 
 Use `feynman packages list` to see which optional packages are available and which are already installed. The `all-extras` preset installs every optional package at once.
+
+`feynman update` updates the Pi packages inside your Feynman environment. It does not upgrade the standalone Feynman app itself. To upgrade the app, rerun the platform installer from the [Installation](/docs/getting-started/installation) guide.
 
 ## Utility commands
 

--- a/website/src/content/docs/reference/package-stack.md
+++ b/website/src/content/docs/reference/package-stack.md
@@ -27,6 +27,8 @@ These are installed by default with every Feynman installation. They provide the
 
 These packages are updated together when you run `feynman update`. You do not need to install them individually.
 
+This package update flow is separate from upgrading the standalone Feynman app. To upgrade the app itself, rerun the installer from the [Installation](/docs/getting-started/installation) guide.
+
 ## Optional packages
 
 Install on demand with `feynman packages install <preset>`. These extend Feynman with capabilities that not every user needs.


### PR DESCRIPTION
﻿## Summary
- add explicit upgrade instructions for the standalone Feynman app on macOS, Linux, and Windows
- clarify that `feynman update` refreshes installed Pi packages, not the standalone runtime bundle
- point CLI and package-stack docs back to the installation guide for app upgrades

## Why
Issue #57 asks how users should update Feynman and whether `feynman update` is the right command. The current docs explain installation well, but they do not clearly separate app upgrades from in-environment package updates.

## User impact
Users now have a direct answer for both paths:
- rerun the installer to upgrade the standalone app
- use `feynman update` to update installed Pi packages inside the Feynman environment

## Validation
- `npm run typecheck`
- `npm run build`
- `cd website && npm run build`
- `cd website && npm run typecheck`

## Notes
- `npm test` still reports pre-existing Windows/path-sensitive failures on this checkout that are unrelated to the docs changes.
- Fixes #57
