### PR TITLE
fix: support api-key model commands and colon model specs

### DIFF
--- a/metadata/commands.mjs
+++ b/metadata/commands.mjs
@@ -86,9 +86,9 @@ export const cliCommandSections = [
 		title: "Model Management",
 		commands: [
 			{ usage: "feynman model list", description: "List available models in Pi auth storage." },
-			{ usage: "feynman model login [id]", description: "Login to a Pi OAuth model provider." },
-			{ usage: "feynman model logout [id]", description: "Logout from a Pi OAuth model provider." },
-			{ usage: "feynman model set <provider/model>", description: "Set the default model." },
+			{ usage: "feynman model login [id]", description: "Authenticate a model provider with OAuth or API-key setup." },
+			{ usage: "feynman model logout [id]", description: "Clear stored auth for a model provider." },
+			{ usage: "feynman model set <provider/model>", description: "Set the default model (also accepts provider:model)." },
 			{ usage: "feynman model tier [value]", description: "View or set the request service tier override." },
 		],
 	},

--- a/src/model/commands.ts
+++ b/src/model/commands.ts
@@ -91,6 +91,31 @@ const API_KEY_PROVIDERS: ApiKeyProviderInfo[] = [
 	{ id: "azure-openai-responses", label: "Azure OpenAI (Responses)", envVar: "AZURE_OPENAI_API_KEY" },
 ];
 
+function resolveApiKeyProvider(input: string): ApiKeyProviderInfo | undefined {
+	const normalizedInput = normalizeProviderId(input);
+	if (!normalizedInput) {
+		return undefined;
+	}
+	return API_KEY_PROVIDERS.find((provider) => provider.id === normalizedInput);
+}
+
+export function resolveModelProviderForCommand(
+	authPath: string,
+	input: string,
+): { kind: "oauth" | "api-key"; id: string } | undefined {
+	const oauthProvider = resolveOAuthProvider(authPath, input);
+	if (oauthProvider) {
+		return { kind: "oauth", id: oauthProvider.id };
+	}
+
+	const apiKeyProvider = resolveApiKeyProvider(input);
+	if (apiKeyProvider) {
+		return { kind: "api-key", id: apiKeyProvider.id };
+	}
+
+	return undefined;
+}
+
 async function selectApiKeyProvider(): Promise<ApiKeyProviderInfo | undefined> {
 	const choices = API_KEY_PROVIDERS.map(
 		(provider) => `${provider.id} — ${provider.label}${provider.envVar ? ` (${provider.envVar})` : ""}`,
@@ -447,9 +472,29 @@ async function verifyCustomProvider(setup: CustomProviderSetup, authPath: string
 	printInfo("Verification: skipped network probe for this API mode.");
 }
 
-async function configureApiKeyProvider(authPath: string): Promise<boolean> {
-	const provider = await selectApiKeyProvider();
+function maybeSetRecommendedDefaultModel(settingsPath: string | undefined, authPath: string): void {
+	if (!settingsPath) {
+		return;
+	}
+
+	const currentSpec = getCurrentModelSpec(settingsPath);
+	const available = getAvailableModelRecords(authPath);
+	const currentValid = currentSpec ? available.some((m) => `${m.provider}/${m.id}` === currentSpec) : false;
+
+	if ((!currentSpec || !currentValid) && available.length > 0) {
+		const recommended = chooseRecommendedModel(authPath);
+		if (recommended) {
+			setDefaultModelSpec(settingsPath, authPath, recommended.spec);
+		}
+	}
+}
+
+async function configureApiKeyProvider(authPath: string, providerId?: string): Promise<boolean> {
+	const provider = providerId ? resolveApiKeyProvider(providerId) : await selectApiKeyProvider();
 	if (!provider) {
+		if (providerId) {
+			throw new Error(`Unknown API-key model provider: ${providerId}`);
+		}
 		printInfo("API key setup cancelled.");
 		return false;
 	}
@@ -512,7 +557,7 @@ async function configureApiKeyProvider(authPath: string): Promise<boolean> {
 }
 
 function resolveAvailableModelSpec(authPath: string, input: string): string | undefined {
-	const normalizedInput = input.trim().toLowerCase();
+	const normalizedInput = input.trim().replace(/^([^/:]+):(.+)$/, "$1/$2").toLowerCase();
 	if (!normalizedInput) {
 		return undefined;
 	}
@@ -574,16 +619,8 @@ export async function authenticateModelProvider(authPath: string, settingsPath?:
 
 	if (selection === 0) {
 		const configured = await configureApiKeyProvider(authPath);
-		if (configured && settingsPath) {
-			const currentSpec = getCurrentModelSpec(settingsPath);
-			const available = getAvailableModelRecords(authPath);
-			const currentValid = currentSpec ? available.some((m) => `${m.provider}/${m.id}` === currentSpec) : false;
-			if ((!currentSpec || !currentValid) && available.length > 0) {
-				const recommended = chooseRecommendedModel(authPath);
-				if (recommended) {
-					setDefaultModelSpec(settingsPath, authPath, recommended.spec);
-				}
-			}
+		if (configured) {
+			maybeSetRecommendedDefaultModel(settingsPath, authPath);
 		}
 		return configured;
 	}
@@ -597,10 +634,24 @@ export async function authenticateModelProvider(authPath: string, settingsPath?:
 }
 
 export async function loginModelProvider(authPath: string, providerId?: string, settingsPath?: string): Promise<boolean> {
+	if (providerId) {
+		const resolvedProvider = resolveModelProviderForCommand(authPath, providerId);
+		if (!resolvedProvider) {
+			throw new Error(`Unknown model provider: ${providerId}`);
+		}
+		if (resolvedProvider.kind === "api-key") {
+			const configured = await configureApiKeyProvider(authPath, resolvedProvider.id);
+			if (configured) {
+				maybeSetRecommendedDefaultModel(settingsPath, authPath);
+			}
+			return configured;
+		}
+	}
+
 	const provider = providerId ? resolveOAuthProvider(authPath, providerId) : await selectOAuthProvider(authPath, "login");
 	if (!provider) {
 		if (providerId) {
-			throw new Error(`Unknown OAuth model provider: ${providerId}`);
+			throw new Error(`Unknown model provider: ${providerId}`);
 		}
 		printInfo("Login cancelled.");
 		return false;
@@ -637,35 +688,38 @@ export async function loginModelProvider(authPath: string, providerId?: string, 
 
 	printSuccess(`Model provider login complete: ${provider.id}`);
 
-	if (settingsPath) {
-		const currentSpec = getCurrentModelSpec(settingsPath);
-		const available = getAvailableModelRecords(authPath);
-		const currentValid = currentSpec
-			? available.some((m) => `${m.provider}/${m.id}` === currentSpec)
-			: false;
-
-		if ((!currentSpec || !currentValid) && available.length > 0) {
-			const recommended = chooseRecommendedModel(authPath);
-			if (recommended) {
-				setDefaultModelSpec(settingsPath, authPath, recommended.spec);
-			}
-		}
-	}
+	maybeSetRecommendedDefaultModel(settingsPath, authPath);
 
 	return true;
 }
 
 export async function logoutModelProvider(authPath: string, providerId?: string): Promise<void> {
-	const provider = providerId ? resolveOAuthProvider(authPath, providerId) : await selectOAuthProvider(authPath, "logout");
-	if (!provider) {
-		if (providerId) {
-			throw new Error(`Unknown OAuth model provider: ${providerId}`);
+	const authStorage = AuthStorage.create(authPath);
+	if (providerId) {
+		const resolvedProvider = resolveModelProviderForCommand(authPath, providerId);
+		if (resolvedProvider) {
+			authStorage.logout(resolvedProvider.id);
+			printSuccess(`Model provider logout complete: ${resolvedProvider.id}`);
+			return;
 		}
+
+		const normalizedProviderId = normalizeProviderId(providerId);
+		if (authStorage.has(normalizedProviderId)) {
+			authStorage.logout(normalizedProviderId);
+			printSuccess(`Model provider logout complete: ${normalizedProviderId}`);
+			return;
+		}
+
+		throw new Error(`Unknown model provider: ${providerId}`);
+	}
+
+	const provider = await selectOAuthProvider(authPath, "logout");
+	if (!provider) {
 		printInfo("Logout cancelled.");
 		return;
 	}
 
-	AuthStorage.create(authPath).logout(provider.id);
+	authStorage.logout(provider.id);
 	printSuccess(`Model provider logout complete: ${provider.id}`);
 }
 

--- a/tests/model-harness.test.ts
+++ b/tests/model-harness.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 
 import { resolveInitialPrompt } from "../src/cli.js";
 import { buildModelStatusSnapshotFromRecords, chooseRecommendedModel } from "../src/model/catalog.js";
-import { setDefaultModelSpec } from "../src/model/commands.js";
+import { resolveModelProviderForCommand, setDefaultModelSpec } from "../src/model/commands.js";
 
 function createAuthPath(contents: Record<string, unknown>): string {
 	const root = mkdtempSync(join(tmpdir(), "feynman-auth-"));
@@ -40,6 +40,40 @@ test("setDefaultModelSpec accepts a unique bare model id from authenticated mode
 	};
 	assert.equal(settings.defaultProvider, "openai");
 	assert.equal(settings.defaultModel, "gpt-5.4");
+});
+
+test("setDefaultModelSpec accepts provider:model syntax for authenticated models", () => {
+	const authPath = createAuthPath({
+		google: { type: "api_key", key: "google-test-key" },
+	});
+	const settingsPath = join(mkdtempSync(join(tmpdir(), "feynman-settings-")), "settings.json");
+
+	setDefaultModelSpec(settingsPath, authPath, "google:gemini-3-pro-preview");
+
+	const settings = JSON.parse(readFileSync(settingsPath, "utf8")) as {
+		defaultProvider?: string;
+		defaultModel?: string;
+	};
+	assert.equal(settings.defaultProvider, "google");
+	assert.equal(settings.defaultModel, "gemini-3-pro-preview");
+});
+
+test("resolveModelProviderForCommand falls back to API-key providers when OAuth is unavailable", () => {
+	const authPath = createAuthPath({});
+
+	const resolved = resolveModelProviderForCommand(authPath, "google");
+
+	assert.equal(resolved?.kind, "api-key");
+	assert.equal(resolved?.id, "google");
+});
+
+test("resolveModelProviderForCommand prefers OAuth when a provider supports both auth modes", () => {
+	const authPath = createAuthPath({});
+
+	const resolved = resolveModelProviderForCommand(authPath, "anthropic");
+
+	assert.equal(resolved?.kind, "oauth");
+	assert.equal(resolved?.id, "anthropic");
 });
 
 test("buildModelStatusSnapshotFromRecords flags an invalid current model and suggests a replacement", () => {

--- a/website/src/content/docs/reference/cli-commands.md
+++ b/website/src/content/docs/reference/cli-commands.md
@@ -23,11 +23,11 @@ This page covers the dedicated Feynman CLI commands and flags. Workflow commands
 | Command | Description |
 | --- | --- |
 | `feynman model list` | List available models in Pi auth storage |
-| `feynman model login [id]` | Login to a Pi OAuth model provider |
-| `feynman model logout [id]` | Logout from a Pi OAuth model provider |
-| `feynman model set <provider:model>` | Set the default model for all sessions |
+| `feynman model login [id]` | Authenticate a model provider with OAuth or API-key setup |
+| `feynman model logout [id]` | Clear stored auth for a model provider |
+| `feynman model set <provider/model>` | Set the default model for all sessions |
 
-These commands manage your model provider configuration. The `model set` command updates `~/.feynman/settings.json` with the new default. The format is `provider:model-name`, for example `anthropic:claude-sonnet-4-20250514`.
+These commands manage your model provider configuration. The `model set` command updates `~/.feynman/settings.json` with the new default. It accepts either `provider/model-name` or `provider:model-name`, for example `anthropic/claude-sonnet-4-20250514` or `anthropic:claude-sonnet-4-20250514`. When you run `feynman model login google` or another API-key provider, Feynman switches into the API-key setup flow automatically instead of requiring the interactive picker.
 
 ## AlphaXiv commands
 


### PR DESCRIPTION
## Summary
- route `feynman model login <provider>` and `feynman model logout <provider>` through a shared resolver so API-key providers like `google` work the same way as OAuth-backed providers
- accept `provider:model` in `feynman model set` in addition to `provider/model`
- update the CLI command metadata and reference docs to describe the supported behavior

## Testing
- `node --import tsx --test tests/model-harness.test.ts`
- `npm run typecheck`
- `npm run build`
- `cd website && npm run build`

Fixes #64
Fixes #65