### PR TITLE
fix: prefer explicitly configured provider when bare model id is ambiguous

### DIFF
--- a/src/model/commands.ts
+++ b/src/model/commands.ts
@@ -528,6 +528,17 @@ function resolveAvailableModelSpec(authPath: string, input: string): string | un
 		return `${exactIdMatches[0]!.provider}/${exactIdMatches[0]!.id}`;
 	}
 
+	// When multiple providers expose the same model ID (e.g. github-copilot is always
+	// available regardless of auth), prefer providers the user has explicitly configured.
+	if (exactIdMatches.length > 1) {
+		const authData = readJson(authPath) as Record<string, unknown>;
+		const configuredProviders = new Set(Object.keys(authData));
+		const configuredMatches = exactIdMatches.filter((model) => configuredProviders.has(model.provider));
+		if (configuredMatches.length === 1) {
+			return `${configuredMatches[0]!.provider}/${configuredMatches[0]!.id}`;
+		}
+	}
+
 	return undefined;
 }
 


### PR DESCRIPTION
## Problem

When a user authenticates a single provider via API key (e.g. `openai`) and runs `feynman model set gpt-5.4`, the command fails with:

> Model not available in Pi auth storage: gpt-5.4. Run `feynman model list` first.

The root cause is that the Pi model registry exposes some providers — specifically `github-copilot` and `minimax` — as available even without explicit user authentication. Because `github-copilot` also exposes `gpt-5.4`, the bare model id is no longer unique: `resolveAvailableModelSpec` finds two matches and falls back to returning `undefined`.

This also caused the test _"setDefaultModelSpec accepts a unique bare model id from authenticated models"_ to fail after `github-copilot` was added to the always-available provider set.

## Solution

When `resolveAvailableModelSpec` finds multiple providers for the same bare model id, it now checks which providers the user has explicitly configured in `auth.json`. If exactly one configured provider matches, that provider is returned. This restores the expected behavior for users who authenticate a single provider (e.g. openai) and want to use a bare model id.

If more than one *configured* provider matches, the call still fails — genuinely ambiguous cases are still rejected.

## Testing

- All 69 existing tests pass (`npm test`)
- TypeScript builds cleanly (`npm run build`)
- The previously failing test `setDefaultModelSpec accepts a unique bare model id from authenticated models` now passes, since `github-copilot` is always-available but `openai` is the only provider in auth.json, making `openai/gpt-5.4` the unambiguous choice.