### PR TITLE
Add section-selective extraction to alpha_get_paper

### DIFF
--- a/extensions/research-tools/alpha-sections.ts
+++ b/extensions/research-tools/alpha-sections.ts
@@ -1,0 +1,130 @@
+const SECTION_ALIASES: Record<string, string[]> = {
+	abstract: ["abstract", "summary", "overview"],
+	introduction: ["introduction", "background", "motivation"],
+	methodology: ["methodology", "methods", "approach", "method"],
+	experiments: ["experiments", "experimental setup", "evaluation setup", "setup"],
+	results: ["results", "findings", "performance"],
+	discussion: ["discussion", "analysis", "interpretation"],
+	limitations: ["limitations", "limit", "weaknesses"],
+	conclusion: ["conclusion", "conclusions", "closing"],
+};
+
+type SectionMap = Record<string, unknown>;
+
+function normalizeToken(value: string): string {
+	return value
+		.trim()
+		.toLowerCase()
+		.replace(/^[#\s]+/, "")
+		.replace(/^[0-9]+(?:\.[0-9]+)*\s+/, "")
+		.replace(/[^a-z\s]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+function toRecord(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	return value as Record<string, unknown>;
+}
+
+function canonicalizeSection(value: string): string | undefined {
+	const token = normalizeToken(value);
+	if (!token) return undefined;
+	for (const [section, aliases] of Object.entries(SECTION_ALIASES)) {
+		if (aliases.includes(token)) return section;
+	}
+	return undefined;
+}
+
+function buildSectionList(section?: string, sections?: string[]): string[] {
+	const tokens = [section, ...(sections ?? [])].filter((value): value is string => typeof value === "string");
+	const unique = new Set<string>();
+	for (const token of tokens) {
+		const normalized = canonicalizeSection(token);
+		if (normalized) unique.add(normalized);
+	}
+	return [...unique];
+}
+
+function pickObjectSections(content: unknown, requested: string[]): SectionMap {
+	const selected: SectionMap = {};
+	const record = toRecord(content);
+	if (!record) return selected;
+
+	const entries = Object.entries(record);
+	for (const section of requested) {
+		const aliases = SECTION_ALIASES[section] ?? [section];
+		for (const [key, value] of entries) {
+			if (aliases.includes(normalizeToken(key))) {
+				selected[section] = value;
+				break;
+			}
+		}
+	}
+
+	const nestedSections = toRecord(record.sections);
+	if (nestedSections) {
+		for (const section of requested) {
+			if (section in selected) continue;
+			const aliases = SECTION_ALIASES[section] ?? [section];
+			for (const [key, value] of Object.entries(nestedSections)) {
+				if (aliases.includes(normalizeToken(key))) {
+					selected[section] = value;
+					break;
+				}
+			}
+		}
+	}
+
+	return selected;
+}
+
+function pickTextSections(content: string, requested: string[]): SectionMap {
+	const selected: SectionMap = {};
+	if (!requested.length) return selected;
+
+	const lines = content.split(/\r?\n/);
+	let activeSection: string | undefined;
+	const buffers = new Map<string, string[]>();
+
+	for (const line of lines) {
+		const maybeSection = canonicalizeSection(line);
+		if (maybeSection && requested.includes(maybeSection)) {
+			activeSection = maybeSection;
+			if (!buffers.has(maybeSection)) buffers.set(maybeSection, []);
+			continue;
+		}
+
+		if (activeSection && /^\s*(?:#{1,6}\s*)?(?:[0-9]+(?:\.[0-9]+)*\s+)?[A-Za-z][A-Za-z\s\-/]{2,80}:?\s*$/.test(line)) {
+			activeSection = undefined;
+		}
+
+		if (activeSection) {
+			buffers.get(activeSection)?.push(line);
+		}
+	}
+
+	for (const section of requested) {
+		const body = (buffers.get(section) ?? []).join("\n").trim();
+		if (body) selected[section] = body;
+	}
+
+	return selected;
+}
+
+export type ExtractPaperSectionsResult = {
+	requested: string[];
+	selected: SectionMap;
+	missing: string[];
+};
+
+export function extractPaperSections(content: unknown, section?: string, sections?: string[]): ExtractPaperSectionsResult {
+	const requested = buildSectionList(section, sections);
+	if (!requested.length) {
+		return { requested: [], selected: {}, missing: [] };
+	}
+
+	const selected = typeof content === "string" ? pickTextSections(content, requested) : pickObjectSections(content, requested);
+	const missing = requested.filter((name) => !(name in selected));
+	return { requested, selected, missing };
+}

--- a/extensions/research-tools/alpha.ts
+++ b/extensions/research-tools/alpha.ts
@@ -10,6 +10,8 @@ import {
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 
+import { extractPaperSections } from "./alpha-sections.js";
+
 function formatText(value: unknown): string {
 	if (typeof value === "string") return value;
 	return JSON.stringify(value, null, 2);
@@ -36,14 +38,38 @@ export function registerAlphaTools(pi: ExtensionAPI): void {
 	pi.registerTool({
 		name: "alpha_get_paper",
 		label: "Alpha Get Paper",
-		description: "Fetch a paper's AI-generated report (or raw full text) plus any local annotation.",
+		description:
+			"Fetch a paper's AI-generated report (or raw full text) plus any local annotation. Optional section filters return only requested sections when detectable.",
 		parameters: Type.Object({
 			paper: Type.String({ description: "arXiv ID, arXiv URL, or alphaXiv URL." }),
 			fullText: Type.Optional(Type.Boolean({ description: "Return raw full text instead of AI report." })),
+			section: Type.Optional(
+				Type.String({
+					description:
+						"Single section to extract from content: abstract, introduction, methodology, experiments, results, discussion, limitations, or conclusion.",
+				}),
+			),
+			sections: Type.Optional(
+				Type.Array(
+					Type.String({
+						description:
+							"Multiple sections to extract from content. Supported values: abstract, introduction, methodology, experiments, results, discussion, limitations, conclusion.",
+					}),
+				),
+			),
 		}),
 		async execute(_toolCallId, params) {
 			const result = await getPaper(params.paper, { fullText: params.fullText });
-			return { content: [{ type: "text", text: formatText(result) }], details: result };
+			const extracted = extractPaperSections(result.content, params.section, params.sections);
+			const filteredResult = extracted.requested.length
+				? {
+						...result,
+						content: Object.keys(extracted.selected).length > 0 ? extracted.selected : result.content,
+						requestedSections: extracted.requested,
+						missingSections: extracted.missing,
+				  }
+				: result;
+			return { content: [{ type: "text", text: formatText(filteredResult) }], details: filteredResult };
 		},
 	});
 

--- a/tests/alpha-sections.test.ts
+++ b/tests/alpha-sections.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { extractPaperSections } from "../extensions/research-tools/alpha-sections.js";
+
+test("extractPaperSections selects canonical sections from object content", () => {
+	const content = {
+		Abstract: "This paper introduces a benchmark.",
+		Methods: "We train a transformer with synthetic data.",
+		Results: "The method improves accuracy by 6 points.",
+	};
+
+	const result = extractPaperSections(content, undefined, ["abstract", "methodology", "results"]);
+
+	assert.deepEqual(result.requested, ["abstract", "methodology", "results"]);
+	assert.deepEqual(result.selected, {
+		abstract: "This paper introduces a benchmark.",
+		methodology: "We train a transformer with synthetic data.",
+		results: "The method improves accuracy by 6 points.",
+	});
+	assert.deepEqual(result.missing, []);
+});
+
+test("extractPaperSections supports nested sections object", () => {
+	const content = {
+		title: "Paper",
+		sections: {
+			"Experimental Setup": "Three datasets and two baselines.",
+			Discussion: "Error analysis indicates domain shift.",
+		},
+	};
+
+	const result = extractPaperSections(content, "experiments");
+
+	assert.deepEqual(result.requested, ["experiments"]);
+	assert.deepEqual(result.selected, {
+		experiments: "Three datasets and two baselines.",
+	});
+	assert.deepEqual(result.missing, []);
+});
+
+test("extractPaperSections parses heading-based sections from text content", () => {
+	const content = [
+		"# Abstract",
+		"A concise summary.",
+		"",
+		"## Introduction",
+		"Intro paragraph.",
+		"",
+		"## 3 Results",
+		"Result paragraph.",
+	].join("\n");
+
+	const result = extractPaperSections(content, undefined, ["abstract", "results", "limitations"]);
+
+	assert.deepEqual(result.requested, ["abstract", "results", "limitations"]);
+	assert.deepEqual(result.selected, {
+		abstract: "A concise summary.",
+		results: "Result paragraph.",
+	});
+	assert.deepEqual(result.missing, ["limitations"]);
+});
+
+test("extractPaperSections ignores unknown section names", () => {
+	const result = extractPaperSections({ abstract: "x" }, "not-a-section", ["abstract", "UNKNOWN"]);
+
+	assert.deepEqual(result.requested, ["abstract"]);
+	assert.deepEqual(result.selected, { abstract: "x" });
+	assert.deepEqual(result.missing, []);
+});

--- a/website/src/content/docs/tools/alphaxiv.md
+++ b/website/src/content/docs/tools/alphaxiv.md
@@ -27,6 +27,7 @@ AlphaXiv gives Feynman access to several capabilities that power the research wo
 
 - **Paper search** -- Find papers by topic, author, keyword, or arXiv ID (`alpha search`)
 - **Full-text retrieval** -- Download and parse complete PDFs for in-depth reading (`alpha get`)
+- **Section-focused extraction (agent tool)** -- In-agent `alpha_get_paper` supports `section` / `sections` filters for abstract/introduction/methodology/experiments/results/discussion/limitations/conclusion when available
 - **Paper Q&A** -- Ask targeted questions about a paper's content (`alpha ask`)
 - **Code inspection** -- Read files from a paper's linked GitHub repository (`alpha code`)
 - **Annotations** -- Persistent local notes on papers across sessions (`alpha annotate`)


### PR DESCRIPTION
## Summary
- add `section` / `sections` parameters to `alpha_get_paper` so paper reads can return targeted sections instead of only full report/full text
- implement robust section extraction for both structured report objects and heading-based raw text with explicit missing-section reporting
- add unit coverage for section extraction behavior and update docs for the new focused-read capability

## Verification
- `npm test -- tests/alpha-sections.test.ts` *(suite still includes one pre-existing unrelated failure in `tests/model-harness.test.ts` expecting `minimax/MiniMax-M2.7`)*
- `npm run typecheck`
- `npm run build`
- `cd website && npm run lint && npm run typecheck && npm run build`