### PR TITLE
Fix sqlite extension gating on Node 20

### DIFF
--- a/src/pi/package-presets.ts
+++ b/src/pi/package-presets.ts
@@ -22,6 +22,7 @@ export const NATIVE_PACKAGE_SOURCES = [
 	"npm:@samfp/pi-memory",
 ] as const;
 
+export const MIN_NATIVE_PACKAGE_NODE_MAJOR = 22;
 export const MAX_NATIVE_PACKAGE_NODE_MAJOR = 24;
 
 export const OPTIONAL_PACKAGE_PRESETS = {
@@ -63,7 +64,8 @@ function parseNodeMajor(version: string): number {
 }
 
 export function supportsNativePackageSources(version = process.versions.node): boolean {
-	return parseNodeMajor(version) <= MAX_NATIVE_PACKAGE_NODE_MAJOR;
+	const major = parseNodeMajor(version);
+	return major >= MIN_NATIVE_PACKAGE_NODE_MAJOR && major <= MAX_NATIVE_PACKAGE_NODE_MAJOR;
 }
 
 export function filterPackageSourcesForCurrentNode<T extends string>(sources: readonly T[], version = process.versions.node): T[] {

--- a/tests/package-ops.test.ts
+++ b/tests/package-ops.test.ts
@@ -159,7 +159,7 @@ test("installPackageSources filters noisy npm chatter but preserves meaningful o
 	assert.doesNotMatch(combined, /npm fund/);
 });
 
-test("installPackageSources skips native packages on unsupported Node majors before invoking npm", async () => {
+test("installPackageSources skips native packages when node:sqlite is unavailable", async () => {
 	const root = mkdtempSync(join(tmpdir(), "feynman-package-ops-"));
 	const workingDir = resolve(root, "project");
 	const agentDir = resolve(root, "agent");
@@ -177,7 +177,7 @@ test("installPackageSources skips native packages on unsupported Node majors bef
 	});
 
 	const originalVersion = process.versions.node;
-	Object.defineProperty(process.versions, "node", { value: "25.0.0", configurable: true });
+	Object.defineProperty(process.versions, "node", { value: "20.20.2", configurable: true });
 	try {
 		const result = await installPackageSources(workingDir, agentDir, ["npm:@kaiserlich-dev/pi-session-search"]);
 		assert.deepEqual(result.installed, []);
@@ -279,7 +279,7 @@ test("updateConfiguredPackages batches multiple npm updates into a single instal
 	assert.ok(invocations[0]?.includes("test-two@latest"));
 });
 
-test("updateConfiguredPackages skips native package updates on unsupported Node majors", async () => {
+test("updateConfiguredPackages skips native package updates when node:sqlite is unavailable", async () => {
 	const root = mkdtempSync(join(tmpdir(), "feynman-package-ops-"));
 	const workingDir = resolve(root, "project");
 	const agentDir = resolve(root, "agent");
@@ -315,7 +315,7 @@ test("updateConfiguredPackages skips native package updates on unsupported Node 
 		ok: true,
 		json: async () => ({ version: "2.0.0" }),
 	})) as unknown as typeof fetch;
-	Object.defineProperty(process.versions, "node", { value: "25.0.0", configurable: true });
+	Object.defineProperty(process.versions, "node", { value: "20.20.2", configurable: true });
 
 	try {
 		const result = await updateConfiguredPackages(workingDir, agentDir);

--- a/tests/pi-settings.test.ts
+++ b/tests/pi-settings.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 
 import {
 	CORE_PACKAGE_SOURCES,
+	filterPackageSourcesForCurrentNode,
 	getOptionalPackagePresetSources,
 	NATIVE_PACKAGE_SOURCES,
 	shouldPruneLegacyDefaultPackages,
@@ -39,7 +40,7 @@ test("normalizeFeynmanSettings seeds the fast core package set", () => {
 	normalizeFeynmanSettings(settingsPath, bundledSettingsPath, "medium", authPath);
 
 	const settings = JSON.parse(readFileSync(settingsPath, "utf8")) as { packages?: string[] };
-	assert.deepEqual(settings.packages, [...CORE_PACKAGE_SOURCES]);
+	assert.deepEqual(settings.packages, filterPackageSourcesForCurrentNode(CORE_PACKAGE_SOURCES));
 });
 
 test("normalizeFeynmanSettings prunes the legacy slow default package set", () => {
@@ -68,7 +69,7 @@ test("normalizeFeynmanSettings prunes the legacy slow default package set", () =
 	normalizeFeynmanSettings(settingsPath, bundledSettingsPath, "medium", authPath);
 
 	const settings = JSON.parse(readFileSync(settingsPath, "utf8")) as { packages?: string[] };
-	assert.deepEqual(settings.packages, [...CORE_PACKAGE_SOURCES]);
+	assert.deepEqual(settings.packages, filterPackageSourcesForCurrentNode(CORE_PACKAGE_SOURCES));
 });
 
 test("optional package presets map friendly aliases", () => {
@@ -78,7 +79,10 @@ test("optional package presets map friendly aliases", () => {
 	assert.equal(shouldPruneLegacyDefaultPackages(["npm:custom"]), false);
 });
 
-test("supportsNativePackageSources disables sqlite-backed packages on Node 25+", () => {
+test("supportsNativePackageSources enables sqlite-backed packages only on Node 22-24", () => {
+	assert.equal(supportsNativePackageSources("20.20.2"), false);
+	assert.equal(supportsNativePackageSources("21.7.3"), false);
+	assert.equal(supportsNativePackageSources("22.0.0"), true);
 	assert.equal(supportsNativePackageSources("24.8.0"), true);
 	assert.equal(supportsNativePackageSources("25.0.0"), false);
 });


### PR DESCRIPTION
## Summary
- tighten native package compatibility gating so sqlite-backed packages are enabled only on Node 22-24
- prevent Node 20/21 from pulling `@samfp/pi-memory` and `@kaiserlich-dev/pi-session-search`, avoiding `node:sqlite` runtime crashes
- align Pi settings and package-ops coverage with `node:sqlite` availability semantics and Node 20 regression scenario

## Verification
- `node --import tsx --test tests/pi-settings.test.ts tests/package-ops.test.ts`
  - note: existing aggregate harness failure still appears in `tests/package-ops.test.ts` despite subtests passing (pre-existing behavior)
- `npm run typecheck`
- `npm run build`
- runtime smoke: `node bin/feynman.js --help`