### PR TITLE
Flag missing web-search config in status and doctor output

### DIFF
--- a/src/pi/web-access.ts
+++ b/src/pi/web-access.ts
@@ -18,6 +18,7 @@ export type PiWebAccessConfig = Record<string, unknown> & {
 
 export type PiWebAccessStatus = {
 	configPath: string;
+	configExists: boolean;
 	searchProvider: PiWebSearchProvider;
 	requestProvider: PiWebSearchProvider;
 	workflow: PiWebSearchWorkflow;
@@ -118,6 +119,7 @@ export function getPiWebAccessStatus(
 
 	return {
 		configPath,
+		configExists: existsSync(configPath),
 		searchProvider,
 		requestProvider,
 		workflow,
@@ -133,7 +135,8 @@ export function getPiWebAccessStatus(
 export function formatPiWebAccessDoctorLines(
 	status: PiWebAccessStatus = getPiWebAccessStatus(),
 ): string[] {
-	return [
+	const configPathSuffix = status.configExists ? "" : " (not created yet)";
+	const lines = [
 		"web access: pi-web-access",
 		`  search route: ${status.routeLabel}`,
 		`  request route: ${status.requestProvider}`,
@@ -142,7 +145,11 @@ export function formatPiWebAccessDoctorLines(
 		`  exa api: ${status.exaConfigured ? "configured" : "not configured"}`,
 		`  gemini api: ${status.geminiApiConfigured ? "configured" : "not configured"}`,
 		`  browser profile: ${status.chromeProfile ?? "default Chromium profile"}`,
-		`  config path: ${status.configPath}`,
+		`  config path: ${status.configPath}${configPathSuffix}`,
 		`  note: ${status.note}`,
 	];
+	if (!status.configExists) {
+		lines.push("  hint: run `feynman search set <auto|perplexity|exa|gemini> [api-key]` to configure web search");
+	}
+	return lines;
 }

--- a/src/search/commands.ts
+++ b/src/search/commands.ts
@@ -13,8 +13,8 @@ const PROVIDER_API_KEY_FIELDS: Partial<Record<PiWebSearchProvider, keyof PiWebAc
 	gemini: "geminiApiKey",
 };
 
-export function printSearchStatus(): void {
-	const status = getPiWebAccessStatus();
+export function printSearchStatus(status = getPiWebAccessStatus()): void {
+	const configPathSuffix = status.configExists ? "" : " (not created yet)";
 	printInfo("Managed by: pi-web-access");
 	printInfo(`Search route: ${status.routeLabel}`);
 	printInfo(`Request route: ${status.requestProvider}`);
@@ -23,7 +23,14 @@ export function printSearchStatus(): void {
 	printInfo(`Exa API configured: ${status.exaConfigured ? "yes" : "no"}`);
 	printInfo(`Gemini API configured: ${status.geminiApiConfigured ? "yes" : "no"}`);
 	printInfo(`Browser profile: ${status.chromeProfile ?? "default Chromium profile"}`);
-	printInfo(`Config path: ${status.configPath}`);
+	printInfo(`Config path: ${status.configPath}${configPathSuffix}`);
+	if (!status.configExists) {
+		printInfo("Not configured yet. Run one of:");
+		printInfo("  feynman search set auto");
+		printInfo("  feynman search set perplexity <api-key>");
+		printInfo("  feynman search set exa <api-key>");
+		printInfo("  feynman search set gemini <api-key>");
+	}
 }
 
 export function setSearchProvider(provider: PiWebSearchProvider, apiKey?: string): void {

--- a/tests/pi-web-access.test.ts
+++ b/tests/pi-web-access.test.ts
@@ -118,3 +118,52 @@ test("formatPiWebAccessDoctorLines reports Pi-managed web access", () => {
 	assert.ok(lines.some((line) => line.includes("search workflow: none")));
 	assert.ok(lines.some((line) => line.includes("/tmp/pi-web-search.json")));
 });
+
+test("getPiWebAccessStatus flags configExists: false when web-search.json is missing", () => {
+	const root = mkdtempSync(join(tmpdir(), "feynman-pi-web-"));
+	const configPath = getPiWebSearchConfigPath(root);
+
+	const status = getPiWebAccessStatus(loadPiWebAccessConfig(configPath), configPath);
+	assert.equal(status.configExists, false);
+});
+
+test("getPiWebAccessStatus flags configExists: true after web-search.json is written", () => {
+	const root = mkdtempSync(join(tmpdir(), "feynman-pi-web-"));
+	const configPath = getPiWebSearchConfigPath(root);
+	savePiWebAccessConfig({ provider: "auto", searchProvider: "auto" }, configPath);
+
+	const status = getPiWebAccessStatus(loadPiWebAccessConfig(configPath), configPath);
+	assert.equal(status.configExists, true);
+});
+
+test("formatPiWebAccessDoctorLines marks missing config path and includes a setup hint", () => {
+	const root = mkdtempSync(join(tmpdir(), "feynman-pi-web-"));
+	const configPath = getPiWebSearchConfigPath(root);
+
+	const lines = formatPiWebAccessDoctorLines(
+		getPiWebAccessStatus(loadPiWebAccessConfig(configPath), configPath),
+	);
+
+	const configLine = lines.find((line) => line.includes("config path:"));
+	assert.ok(configLine, "expected a config path line");
+	assert.ok(configLine!.includes("(not created yet)"), `expected '(not created yet)' marker, got: ${configLine}`);
+	assert.ok(
+		lines.some((line) => line.includes("hint:") && line.includes("feynman search set")),
+		"expected a hint line pointing to `feynman search set`",
+	);
+});
+
+test("formatPiWebAccessDoctorLines omits marker and hint when config exists", () => {
+	const root = mkdtempSync(join(tmpdir(), "feynman-pi-web-"));
+	const configPath = getPiWebSearchConfigPath(root);
+	savePiWebAccessConfig({ provider: "auto", searchProvider: "auto" }, configPath);
+
+	const lines = formatPiWebAccessDoctorLines(
+		getPiWebAccessStatus(loadPiWebAccessConfig(configPath), configPath),
+	);
+
+	const configLine = lines.find((line) => line.includes("config path:"));
+	assert.ok(configLine, "expected a config path line");
+	assert.ok(!configLine!.includes("(not created yet)"), `did not expect '(not created yet)' marker: ${configLine}`);
+	assert.ok(!lines.some((line) => line.includes("hint:")), "did not expect a hint line when config exists");
+});

--- a/tests/search-commands.test.ts
+++ b/tests/search-commands.test.ts
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { printSearchStatus } from "../src/search/commands.js";
+import {
+	getPiWebAccessStatus,
+	getPiWebSearchConfigPath,
+	loadPiWebAccessConfig,
+	savePiWebAccessConfig,
+} from "../src/pi/web-access.js";
+
+function captureConsoleLog(fn: () => void): string[] {
+	const lines: string[] = [];
+	const original = console.log;
+	console.log = (...args: unknown[]) => {
+		lines.push(args.map((arg) => String(arg)).join(" "));
+	};
+	try {
+		fn();
+	} finally {
+		console.log = original;
+	}
+	return lines;
+}
+
+function stripAnsi(line: string): string {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI strip
+	return line.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+test("printSearchStatus marks config path and prints setup hint when web-search.json is missing", () => {
+	const root = mkdtempSync(join(tmpdir(), "feynman-search-cmds-"));
+	const configPath = getPiWebSearchConfigPath(root);
+	const status = getPiWebAccessStatus(loadPiWebAccessConfig(configPath), configPath);
+
+	const output = captureConsoleLog(() => printSearchStatus(status)).map(stripAnsi);
+
+	const configLine = output.find((line) => line.includes("Config path:"));
+	assert.ok(configLine, "expected Config path line");
+	assert.ok(configLine!.includes("(not created yet)"), `expected '(not created yet)' marker, got: ${configLine}`);
+	assert.ok(
+		output.some((line) => line.toLowerCase().includes("feynman search set")),
+		"expected a hint referencing `feynman search set`",
+	);
+});
+
+test("printSearchStatus omits marker and hint when web-search.json exists", () => {
+	const root = mkdtempSync(join(tmpdir(), "feynman-search-cmds-"));
+	const configPath = getPiWebSearchConfigPath(root);
+	savePiWebAccessConfig({ provider: "auto", searchProvider: "auto" }, configPath);
+	const status = getPiWebAccessStatus(loadPiWebAccessConfig(configPath), configPath);
+
+	const output = captureConsoleLog(() => printSearchStatus(status)).map(stripAnsi);
+
+	const configLine = output.find((line) => line.includes("Config path:"));
+	assert.ok(configLine, "expected Config path line");
+	assert.ok(!configLine!.includes("(not created yet)"), `did not expect '(not created yet)' marker: ${configLine}`);
+	assert.ok(
+		!output.some((line) => line.toLowerCase().includes("feynman search set")),
+		"did not expect a setup hint when config exists",
+	);
+});


### PR DESCRIPTION
## Summary

  On a fresh install with no prior `feynman search set ...`, both `feynman search status` and
   `feynman doctor` print a fully-populated web-access config block and a `config path:` that
   does not exist on disk. The file is only created on the first `feynman search set` call,
  so the output misleads users into thinking web search is configured and ready.

  This PR surfaces the missing-file state explicitly. It is a UX-only change — no runtime
  behavior is modified.

  ## Changes

  - Add `configExists: boolean` to `PiWebAccessStatus`, populated via
  `existsSync(configPath)` in `getPiWebAccessStatus()`.
  - In `formatPiWebAccessDoctorLines()`: append ` (not created yet)` to the config path line
  and a `hint:` line pointing at `feynman search set` when the file is absent.
  - In `printSearchStatus()` (`feynman search status`): append the same marker and a short
  block of setup examples when the file is absent. The function now also accepts an optional
  status override for testability.

  Runtime behavior is unchanged — `loadPiWebAccessConfig()` still returns `{}` for a missing
  file, and web access still auto-falls-back through Perplexity → Exa → Gemini when no config
   is present.

  ## Out of scope / follow-ups

  - Adding a web-search step to the `feynman setup` wizard.
  - Any runtime protection (e.g., refusing to register the `web_search` tool when
  unconfigured) — happy to follow up in a separate PR if maintainers want it.

  ## Before / after

  Before (fresh machine, no `web-search.json`):
    config path: /Users/…/.feynman/web-search.json
    note: Pi web-access will try Perplexity, then Exa, then Gemini API, then Gemini Browser.

  After:
    config path: /Users/…/.feynman/web-search.json (not created yet)
    note: Pi web-access will try Perplexity, then Exa, then Gemini API, then Gemini Browser.
    hint: run feynman search set <auto|perplexity|exa|gemini> [api-key] to configure web
  search

  After running `feynman search set auto`, both outputs no longer show the marker or hint.

  ## Test plan

  - [x] `npm test` — 132/132 pass, 6 new tests added
  - [x] `npm run typecheck` — clean
  - [x] `npm run build` — clean
  - New tests in `tests/pi-web-access.test.ts`: `configExists` flag toggles with file
  presence; doctor lines include/omit marker and hint accordingly.
  - New `tests/search-commands.test.ts`: `printSearchStatus` surfaces the marker + setup hint
   when missing and omits them when present.
  - [x] Manual smoke: deleted local `~/.feynman/web-search.json`, confirmed both `feynman
  search status` and `feynman doctor` show the marker + hint; re-ran `feynman search set
  auto`, confirmed they disappear. *(Please verify locally as well.)*