### PR TITLE
Warn when workflows launch with a local model

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,6 +33,7 @@ import { getConfiguredServiceTier, normalizeServiceTier, setConfiguredServiceTie
 import {
 	authenticateModelProvider,
 	getCurrentModelSpec,
+	isLocalModelProvider,
 	loginModelProvider,
 	logoutModelProvider,
 	printModelList,
@@ -415,6 +416,12 @@ export function resolvePiPromptOptions(
 	return { initialPrompt: resolvedPrompt };
 }
 
+export function buildLocalModelWorkflowNotice(modelSpec: string, workflowName: string): string {
+	const WARN = "\x1b[33m";
+	const RESET_CODE = "\x1b[0m";
+	return `${WARN}⚠ ${modelSpec} is a local provider. Small local models often ignore /${workflowName}'s multi-step workflow and return a chat-only reply with no artifacts under outputs/. If this run produces no files, switch to a stronger model with \`feynman model set <provider/model>\`.${RESET_CODE}`;
+}
+
 export function appendWorkflowFlagPositionals(
 	command: string | undefined,
 	rest: string[],
@@ -672,6 +679,18 @@ export async function main(): Promise<void> {
 	const workflowCommandNames = new Set(readPromptSpecs(appRoot).filter((s) => s.topLevelCli).map((s) => s.name));
 	const workflowRest = appendWorkflowFlagPositionals(command, rest, values);
 	const promptOptions = resolvePiPromptOptions(command, workflowRest, values.prompt, workflowCommandNames);
+
+	let preLaunchNotice: string | undefined;
+	if (command && workflowCommandNames.has(command)) {
+		const effectiveSpec = explicitModelSpec ?? getCurrentModelSpec(feynmanSettingsPath);
+		if (effectiveSpec) {
+			const providerId = effectiveSpec.split("/")[0] ?? "";
+			if (isLocalModelProvider(feynmanAuthPath, providerId)) {
+				preLaunchNotice = buildLocalModelWorkflowNotice(effectiveSpec, command);
+			}
+		}
+	}
+
 	await launchPiChat({
 		appRoot,
 		workingDir,
@@ -681,6 +700,7 @@ export async function main(): Promise<void> {
 		mode,
 		thinkingLevel: launchThinkingLevel,
 		explicitModelSpec,
+		preLaunchNotice,
 		...promptOptions,
 	});
 }

--- a/src/model/commands.ts
+++ b/src/model/commands.ts
@@ -1,5 +1,5 @@
 import { AuthStorage } from "@mariozechner/pi-coding-agent";
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { exec as execCallback } from "node:child_process";
 import { promisify } from "node:util";
 
@@ -206,6 +206,26 @@ function normalizeCustomProviderBaseUrl(
 
 function isLocalBaseUrl(baseUrl: string): boolean {
 	return /^(https?:\/\/)?(localhost|127\.0\.0\.1|0\.0\.0\.0)(:|\/|$)/i.test(baseUrl);
+}
+
+const LOCAL_PROVIDER_IDS = new Set(["ollama", "lm-studio", "vllm", "llama-cpp", "llamacpp"]);
+
+export function isLocalModelProvider(authPath: string, providerId: string): boolean {
+	if (!providerId) {
+		return false;
+	}
+	if (LOCAL_PROVIDER_IDS.has(providerId)) {
+		return true;
+	}
+	try {
+		const raw = readFileSync(getModelsJsonPath(authPath), "utf8");
+		const parsed = JSON.parse(raw) as { providers?: Record<string, { baseUrl?: unknown }> };
+		const provider = parsed?.providers?.[providerId];
+		if (provider && typeof provider.baseUrl === "string" && isLocalBaseUrl(provider.baseUrl)) {
+			return true;
+		}
+	} catch {}
+	return false;
 }
 
 async function resolveApiKeyConfig(apiKeyConfig: string): Promise<string | undefined> {

--- a/src/pi/launch.ts
+++ b/src/pi/launch.ts
@@ -49,6 +49,10 @@ export async function launchPiChat(options: PiRuntimeOptions): Promise<void> {
 		process.stdout.write("\x1b[2J\x1b[3J\x1b[H");
 	}
 
+	if (options.preLaunchNotice) {
+		process.stdout.write(`${options.preLaunchNotice}\n`);
+	}
+
 	const wrapperPath = useBuiltWrapper ? piCliWrapperPath : piCliWrapperSourcePath;
 	const importArgs = useDevPolyfill
 		? ["--import", toNodeImportSpecifier(tsxLoaderPath), "--import", toNodeImportSpecifier(promisePolyfillSourcePath)]

--- a/src/pi/runtime.ts
+++ b/src/pi/runtime.ts
@@ -21,6 +21,7 @@ export type PiRuntimeOptions = {
 	explicitModelSpec?: string;
 	oneShotPrompt?: string;
 	initialPrompt?: string;
+	preLaunchNotice?: string;
 };
 
 export function getFeynmanNpmPrefixPath(feynmanAgentDir: string): string {

--- a/tests/model-harness.test.ts
+++ b/tests/model-harness.test.ts
@@ -4,9 +4,9 @@ import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { appendWorkflowFlagPositionals, resolveInitialPrompt, resolvePiPromptOptions, resolveThinkingConfig, shouldRunInteractiveSetup } from "../src/cli.js";
+import { appendWorkflowFlagPositionals, buildLocalModelWorkflowNotice, resolveInitialPrompt, resolvePiPromptOptions, resolveThinkingConfig, shouldRunInteractiveSetup } from "../src/cli.js";
 import { buildModelStatusSnapshotFromRecords, chooseRecommendedModel, getAvailableModelRecords } from "../src/model/catalog.js";
-import { resolveModelProviderForCommand, setDefaultModelSpec } from "../src/model/commands.js";
+import { isLocalModelProvider, resolveModelProviderForCommand, setDefaultModelSpec } from "../src/model/commands.js";
 import { createModelRegistry } from "../src/model/registry.js";
 
 function createAuthPath(contents: Record<string, unknown>): string {
@@ -297,4 +297,38 @@ test("shouldRunInteractiveSetup skips onboarding for explicit model overrides or
 
 	assert.equal(shouldRunInteractiveSetup("openai/gpt-5.4", undefined, true, authPath), false);
 	assert.equal(shouldRunInteractiveSetup(undefined, undefined, false, authPath), false);
+});
+
+test("isLocalModelProvider flags known local provider ids without consulting models.json", () => {
+	const authPath = createAuthPath({});
+	assert.equal(isLocalModelProvider(authPath, "ollama"), true);
+	assert.equal(isLocalModelProvider(authPath, "lm-studio"), true);
+	assert.equal(isLocalModelProvider(authPath, "vllm"), true);
+	assert.equal(isLocalModelProvider(authPath, "anthropic"), false);
+	assert.equal(isLocalModelProvider(authPath, ""), false);
+});
+
+test("isLocalModelProvider flags custom providers whose models.json baseUrl points at localhost", () => {
+	const authPath = createAuthPath({});
+	const modelsJsonPath = join(authPath, "..", "models.json");
+	writeFileSync(
+		modelsJsonPath,
+		JSON.stringify({
+			providers: {
+				"my-proxy": { baseUrl: "http://127.0.0.1:8000/v1" },
+				openrouter: { baseUrl: "https://openrouter.ai/api/v1" },
+			},
+		}) + "\n",
+		"utf8",
+	);
+
+	assert.equal(isLocalModelProvider(authPath, "my-proxy"), true);
+	assert.equal(isLocalModelProvider(authPath, "openrouter"), false);
+});
+
+test("buildLocalModelWorkflowNotice names the configured model and the workflow", () => {
+	const notice = buildLocalModelWorkflowNotice("ollama/gemma4:latest", "deepresearch");
+	assert.ok(notice.includes("ollama/gemma4:latest"));
+	assert.ok(notice.includes("/deepresearch"));
+	assert.ok(notice.includes("feynman model set"));
 });


### PR DESCRIPTION
## Summary

- Small local models (ollama/gemma4, ollama/qwen3.5, etc.) ignore the multi-step `/deepresearch` workflow prompt and return a chat-only explainer with no files under `outputs/`, which is what @eetorres hit in #131 and #132.
- On CLI workflow launch (e.g. `feynman deepresearch "..."`), detect local providers — known ids (`ollama`, `lm-studio`, `vllm`, `llama-cpp`) plus any `models.json` provider whose `baseUrl` points at localhost — and print a one-line notice after Pi's screen clear so it stays visible above the welcome panel.
- The notice names the active model and the workflow, and points at `feynman model set <provider/model>` as the fix. Targets CLI-level workflow invocations only; in-REPL `/deepresearch` goes through Pi and isn't touched.

Closes #131
Closes #132

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — new coverage in `tests/model-harness.test.ts` for `isLocalModelProvider` (known ids + localhost `baseUrl`) and `buildLocalModelWorkflowNotice` wording.
- [ ] Manual: `feynman model set ollama/gemma4:latest` then `feynman deepresearch "alloys for high temperature applications"` — yellow notice appears above the Pi welcome panel.
- [ ] Manual: same CLI invocation with `anthropic/claude-opus-4-6` — no notice printed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)