### PR TITLE
feat: add allowBrowserCookies config flag (default: disabled)

### DIFF
--- a/src/pi/web-access.ts
+++ b/src/pi/web-access.ts
@@ -14,6 +14,7 @@ export type PiWebAccessConfig = Record<string, unknown> & {
 	exaApiKey?: string;
 	geminiApiKey?: string;
 	chromeProfile?: string;
+	allowBrowserCookies?: boolean;
 };
 
 export type PiWebAccessStatus = {
@@ -26,6 +27,7 @@ export type PiWebAccessStatus = {
 	exaConfigured: boolean;
 	geminiApiConfigured: boolean;
 	chromeProfile?: string;
+	allowBrowserCookies: boolean;
 	routeLabel: string;
 	note: string;
 };
@@ -115,6 +117,7 @@ export function getPiWebAccessStatus(
 	const exaConfigured = Boolean(normalizeNonEmptyString(config.exaApiKey));
 	const geminiApiConfigured = Boolean(normalizeNonEmptyString(config.geminiApiKey));
 	const chromeProfile = normalizeNonEmptyString(config.chromeProfile);
+	const allowBrowserCookies = config.allowBrowserCookies === true;
 	const effectiveProvider = searchProvider;
 
 	return {
@@ -127,6 +130,7 @@ export function getPiWebAccessStatus(
 		exaConfigured,
 		geminiApiConfigured,
 		chromeProfile,
+		allowBrowserCookies,
 		routeLabel: formatRouteLabel(effectiveProvider),
 		note: formatRouteNote(effectiveProvider),
 	};
@@ -144,6 +148,7 @@ export function formatPiWebAccessDoctorLines(
 		`  perplexity api: ${status.perplexityConfigured ? "configured" : "not configured"}`,
 		`  exa api: ${status.exaConfigured ? "configured" : "not configured"}`,
 		`  gemini api: ${status.geminiApiConfigured ? "configured" : "not configured"}`,
+		`  browser cookies: ${status.allowBrowserCookies ? "allowed" : "disabled (set allowBrowserCookies: true to enable)"}`,
 		`  browser profile: ${status.chromeProfile ?? "default Chromium profile"}`,
 		`  config path: ${status.configPath}${configPathSuffix}`,
 		`  note: ${status.note}`,

--- a/src/search/commands.ts
+++ b/src/search/commands.ts
@@ -22,7 +22,7 @@ export function printSearchStatus(status = getPiWebAccessStatus()): void {
 	printInfo(`Perplexity API configured: ${status.perplexityConfigured ? "yes" : "no"}`);
 	printInfo(`Exa API configured: ${status.exaConfigured ? "yes" : "no"}`);
 	printInfo(`Gemini API configured: ${status.geminiApiConfigured ? "yes" : "no"}`);
-	printInfo(`Browser profile: ${status.chromeProfile ?? "default Chromium profile"}`);
+	printInfo(`Browser cookies: ${status.allowBrowserCookies ? "allowed" : "disabled"}`);
 	printInfo(`Config path: ${status.configPath}${configPathSuffix}`);
 	if (!status.configExists) {
 		printInfo("Not configured yet. Run one of:");


### PR DESCRIPTION
## Problem

On macOS, the Gemini Web fallback in `pi-web-access` reads Chrome cookies by calling `security find-generic-password`, which triggers a **Keychain Access popup**. This happens automatically with no user consent on every `web_search` and `fetch_content` call that falls through to the Gemini Web provider.

Users see a system dialog asking to grant access to "Chrome Safe Storage" — which looks like the tool is trying to access saved passwords. This erodes trust even though the intent is just to authenticate with Gemini Web.

Ref: #140

## Changes

**`src/pi/web-access.ts`**
- Added `allowBrowserCookies` field to `PiWebAccessConfig` type (default: `false`)
- Added `allowBrowserCookies` to `PiWebAccessStatus` for doctor/status reporting
- `feynman doctor` now shows `browser cookies: disabled` by default with a hint to enable

**`src/search/commands.ts`**
- `feynman search status` shows the browser cookies flag instead of the browser profile

## How It Works

The config file (`~/.pi/web-search.json` or `~/.feynman/web-search.json`) gains a new optional field:

```json
{
  "allowBrowserCookies": true
}
```

When `false` (the default), the `pi-web-access` package should skip the `isGeminiWebAvailable()` call entirely, avoiding any Keychain access. The corresponding `pi-web-access` change to check this flag is tracked at https://github.com/nicobailon/pi-web-access — this PR prepares the config layer.

## What This Does NOT Change

- No behavior change for users who have API keys configured (Exa, Perplexity, Gemini API) — those paths never touch Keychain
- Users who want Gemini Web can opt in with `"allowBrowserCookies": true`

## Checks

- `npm run typecheck` — passes
- `npm run build` — passes
- `npm test` — one pre-existing failure (pandoc path, environment-specific)