### PR TITLE
fix prune version drift and harden models.json / readJson.

### DIFF
--- a/scripts/patch-embedded-pi.mjs
+++ b/scripts/patch-embedded-pi.mjs
@@ -102,7 +102,7 @@ const workspaceManifestPath = resolve(workspaceDir, ".runtime-manifest.json");
 const workspaceArchivePath = resolve(appRoot, ".feynman", "runtime-workspace.tgz");
 const workspaceSetupLockDir = resolve(appRoot, ".feynman", ".workspace-setup.lock");
 const globalNodeModulesRoot = resolve(feynmanNpmPrefix, "lib", "node_modules");
-const PRUNE_VERSION = 3;
+const PRUNE_VERSION = 4;
 const WORKSPACE_SETUP_LOCK_STALE_MS = 300000;
 const NATIVE_PACKAGE_SPECS = new Set([
 	"@kaiserlich-dev/pi-session-search",

--- a/src/model/models-json.ts
+++ b/src/model/models-json.ts
@@ -1,6 +1,18 @@
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
+const UNSAFE_PROVIDER_ID = /[./\\]/;
+
+function validateProviderId(providerId: string): { ok: true } | { ok: false; error: string } {
+	if (!providerId || typeof providerId !== "string") {
+		return { ok: false, error: "provider id must be a non-empty string" };
+	}
+	if (UNSAFE_PROVIDER_ID.test(providerId)) {
+		return { ok: false, error: `provider id "${providerId}" contains unsafe characters (dots or slashes)` };
+	}
+	return { ok: true };
+}
+
 type ModelsJson = {
 	providers?: Record<string, Record<string, unknown>>;
 };
@@ -50,6 +62,11 @@ export function upsertProviderConfig(
 	providerId: string,
 	patch: ProviderConfigPatch,
 ): { ok: true } | { ok: false; error: string } {
+	const idCheck = validateProviderId(providerId);
+	if (!idCheck.ok) {
+		return idCheck;
+	}
+
 	const loaded = readModelsJson(modelsJsonPath);
 	if (!loaded.ok) {
 		return loaded;

--- a/src/pi/settings.ts
+++ b/src/pi/settings.ts
@@ -91,7 +91,8 @@ export function readJson(path: string): Record<string, unknown> {
 
 	try {
 		return JSON.parse(readFileSync(path, "utf8"));
-	} catch {
+	} catch (error) {
+		process.stderr.write(`[feynman] warning: failed to parse ${path}, treating as empty (${error instanceof Error ? error.message : "unknown error"})\n`);
 		return {};
 	}
 }

--- a/tests/models-json.test.ts
+++ b/tests/models-json.test.ts
@@ -72,3 +72,19 @@ test("upsertProviderConfig writes LiteLLM proxy config without master key", () =
 	assert.equal(parsed.providers.litellm.authHeader, false);
 	assert.deepEqual(parsed.providers.litellm.models, [{ id: "llama3" }]);
 });
+
+test("upsertProviderConfig rejects provider ids with path traversal chars", () => {
+	const dir = mkdtempSync(join(tmpdir(), "feynman-models-"));
+	const modelsPath = join(dir, "models.json");
+
+	const withDots = upsertProviderConfig(modelsPath, "../etc/passwd", {
+		baseUrl: "http://localhost:11434/v1",
+	});
+	assert.equal(withDots.ok, false);
+	assert.ok(withDots.ok === false && "error" in withDots);
+
+	const withSlash = upsertProviderConfig(modelsPath, "foo/bar", {
+		baseUrl: "http://localhost:11434/v1",
+	});
+	assert.equal(withSlash.ok, false);
+});


### PR DESCRIPTION
- bump PRUNE_VERSION to 4 in patch-embedded-pi to match prepare-runtime-workspace (was stuck at 3, causing unnecessary workspace reinstalls)
- readJson() now warns to stderr when a file exists but fails to parse, instead of silently returning {}.. super helpful for debugging corrupted settings
- reject provider ids with dots/slashes in upsertProviderConfig to prevent path traversal via models.json
 (Found these bugss while testing the tool)