### PR TITLE
Register Kimi Coding Plan models in research preferences

### DIFF
--- a/src/model/catalog.ts
+++ b/src/model/catalog.ts
@@ -109,6 +109,14 @@ const RESEARCH_MODEL_PREFERENCES = [
 		reason: "good fallback when MiniMax is the available research model",
 	},
 	{
+		spec: "kimi-coding/kimi-for-coding",
+		reason: "Kimi Coding Plan stable ID, auto-maps to latest backend model",
+	},
+	{
+		spec: "kimi-coding/k2p6",
+		reason: "Kimi K2.6 with strong reasoning for coding and research tasks",
+	},
+	{
 		spec: "kimi-coding/kimi-k2-thinking",
 		reason: "good fallback when Kimi is the available research model",
 	},

--- a/tests/model-harness.test.ts
+++ b/tests/model-harness.test.ts
@@ -194,6 +194,33 @@ test("chooseRecommendedModel prefers MiniMax M2.7 over highspeed when that is th
 	}
 });
 
+test("chooseRecommendedModel prefers kimi-for-coding when Kimi Coding is the authenticated provider", () => {
+	const envKeys = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY", "OPENROUTER_API_KEY"];
+	const savedEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+
+	for (const key of envKeys) {
+		delete process.env[key];
+	}
+
+	try {
+		const authPath = createAuthPath({
+			"kimi-coding": { type: "api_key", key: "kimi-test-key" },
+		});
+
+		const recommendation = chooseRecommendedModel(authPath);
+
+		assert.equal(recommendation?.spec, "kimi-coding/kimi-for-coding");
+	} finally {
+		for (const [key, value] of Object.entries(savedEnv)) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	}
+});
+
 test("resolveInitialPrompt maps top-level research commands to Pi slash workflows", () => {
 	const workflows = new Set([
 		"lit",


### PR DESCRIPTION
This pull request adds new Kimi Coding models to the research model preferences and introduces a test to ensure the correct model is recommended when Kimi Coding is the authenticated provider. The changes improve model selection logic and test coverage for model recommendations.

Model preference updates:
* Added `kimi-coding/kimi-for-coding` and `kimi-coding/k2p6` to the `RESEARCH_MODEL_PREFERENCES` list in `src/model/catalog.ts`, providing more options for coding and research tasks.

Testing improvements:
* Added a test in `tests/model-harness.test.ts` to verify that `chooseRecommendedModel` prefers `kimi-for-coding` when Kimi Coding is the only authenticated provider.