### PR TITLE
fix: restrict web search config file permissions

### DIFF
--- a/src/pi/web-access.ts
+++ b/src/pi/web-access.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { getFeynmanHome } from "../config/paths.js";
 
@@ -86,6 +86,12 @@ export function savePiWebAccessConfig(
 
 	mkdirSync(dirname(configPath), { recursive: true });
 	writeFileSync(configPath, JSON.stringify(merged, null, 2) + "\n", "utf8");
+	// web-search.json can contain provider API keys; default to user-only permissions.
+	try {
+		chmodSync(configPath, 0o600);
+	} catch {
+		// ignore permission errors (best-effort)
+	}
 }
 
 function formatRouteLabel(provider: PiWebSearchProvider): string {

--- a/tests/pi-web-access.test.ts
+++ b/tests/pi-web-access.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -41,6 +41,18 @@ test("savePiWebAccessConfig merges updates and deletes undefined values", () => 
 	assert.deepEqual(loadPiWebAccessConfig(configPath), {
 		perplexityApiKey: "pplx_...",
 	});
+});
+
+test("savePiWebAccessConfig restricts web-search.json permissions", { skip: process.platform === "win32" }, () => {
+	const root = mkdtempSync(join(tmpdir(), "feynman-pi-web-"));
+	const configPath = getPiWebSearchConfigPath(root);
+
+	savePiWebAccessConfig({
+		searchProvider: "exa",
+		exaApiKey: "exa_secret",
+	}, configPath);
+
+	assert.equal(statSync(configPath).mode & 0o777, 0o600);
 });
 
 test("getPiWebAccessStatus reads Pi web-access config directly", () => {


### PR DESCRIPTION
## Summary
- Restrict `web-search.json` to user-only permissions after writes.
- Align web search credential storage with `models.json`, which already uses `0600` permissions.
- Add regression coverage for the saved config mode on POSIX platforms.

## Root Cause
`web-search.json` can store provider API keys such as Perplexity, Exa, and Gemini keys. Unlike `models.json`, the web-search config writer did not explicitly restrict file permissions after writing the file, so new files could inherit a permissive process umask.

## Security Impact
This reduces the chance that local users on the same machine can read search provider credentials from the Feynman config directory.

## Validation
- `git diff --check`
- `node --import tsx --test --test-concurrency=1 tests/pi-web-access.test.ts`
- `npm run typecheck`
- `npm run build`

## Notes
Full `npm test` was also attempted in my local shell, but this machine is on Node 25.3.0 while Feynman supports Node 20.19.0 through 22.x. The unsupported-Node run fails in existing Node-version-sensitive package settings expectations unrelated to this change.
