### PR TITLE
fix(header): guard docker probe so Windows cmd.exe does not emit GBK error

### DIFF
--- a/extensions/research-tools/header.ts
+++ b/extensions/research-tools/header.ts
@@ -150,7 +150,8 @@ function detectSystemResources(): SystemResources {
 	} catch {}
 
 	try {
-		execSync("command -v docker >/dev/null 2>&1", { timeout: 500 });
+		const probe = process.platform === "win32" ? "where docker" : "command -v docker";
+		execSync(probe, { timeout: 500, stdio: "ignore" });
 		cachedResources.docker = true;
 	} catch {}
 


### PR DESCRIPTION
## Summary

`detectSystemResources()` in `extensions/research-tools/header.ts` runs `command -v docker >/dev/null 2>&1` on every platform without a guard. On Windows this leaks a localized GBK-encoded error to stderr at every interactive launch, which Feynman's UTF-8 terminal renders as mojibake.

## Repro on Windows

Run Feynman in any UTF-8 PowerShell on a system whose Windows display language is Simplified Chinese (other locales reproduce with their own localized "path not found" message). Every interactive launch prints:

```
ϵͳ�Ҳ���ָ����·����
```

That is GBK bytes for `系统找不到指定的路径` (`The system cannot find the path specified`, `ERROR_PATH_NOT_FOUND`, code 3).

## Root cause

- `command -v` is a bash builtin; it does not exist in `cmd.exe`.
- `/dev/null` is a Unix special file; on Windows there is no path `\dev\null`.
- When Node spawns the unguarded command on Windows, `cmd.exe` parses `>/dev/null 2>&1`, fails to open the redirection target, and writes its localized error directly to the inherited stderr handle in GBK **before** Node's `child_process` can pipe or capture it. The wrapping `try/catch` does not help because the bytes have already left the child process via the parent's stderr fd.
- Feynman's terminal is UTF-8, so the GBK bytes render as mojibake.

For reference, this is the same class of bug that PR #7 fixed for the CLI bootstrap (`sh` not available on Windows, switched to `where`). The same lesson just had not reached this header probe.

## Fix

```diff
 try {
-    execSync("command -v docker >/dev/null 2>&1", { timeout: 500 });
+    const probe = process.platform === "win32" ? "where docker" : "command -v docker";
+    execSync(probe, { timeout: 500, stdio: "ignore" });
     cachedResources.docker = true;
 } catch {}
```

- `where docker` is the cmd.exe equivalent of `command -v docker`.
- `stdio: "ignore"` lets Node redirect the child's stdio at the OS level, so we drop the shell-level `>/dev/null 2>&1`. That sidesteps the original bug class entirely instead of just translating the redirection to `>nul 2>nul`.
- The shape now matches the platform guard a few lines above for the macOS `sysctl` probe and the `where`/`command -v` split already used in `src/system/executables.ts` and `scripts/patch-embedded-pi.mjs`.

## Audit

I grepped the repo for unguarded Unix-only spawn patterns (`command -v`, `>/dev/null`, `2>/dev/null`, raw `sysctl`, `which`). Findings:

- `extensions/research-tools/header.ts` — fixed here. The `sysctl` branch a few lines above is already correctly gated by `process.platform === "darwin"`.
- `src/system/executables.ts` and `scripts/patch-embedded-pi.mjs` — already use the right `where`/`command -v` split with `stdio: ["ignore", "pipe", "ignore"]`.
- `tests/install-skills.test.ts` — its Unix-only smoke test is correctly skipped via `{ skip: process.platform === "win32" }`.
- Shell installers under `scripts/install/` and `website/public/` are platform-specific by design.

So the header probe was the only outstanding instance.

## Verification

- `npm run typecheck` &mdash; pass.
- `npm run build` &mdash; pass.
- `npm test` &mdash; pre-existing Windows path-assertion failures in `tests/pi-runtime.test.ts` and `tests/pi-web-access.test.ts` (POSIX paths hardcoded in expectations, e.g. `'/repo/feynman/...'` vs Windows `'C:\\repo\\feynman\\...'`). None of them touch `extensions/research-tools/header.ts` or the docker probe; this PR does not change their behavior.
- Manually re-launched Feynman on Windows after applying the same patch on the installed bundle: the GBK mojibake line is gone, docker detection still works (returns `true` when Docker Desktop is on `PATH`).

## Risk

- Non-Windows: identical behavior (`command -v docker` is still the probe; only the redirection moves from shell-level `>/dev/null 2>&1` to Node-level `stdio: "ignore"`, which is functionally equivalent for a probe that ignores stdout/stderr).
- Windows: now correctly probes via `where docker` instead of failing on every launch.
- No new dependencies, no new tests required (the change is a platform guard around an existing best-effort probe; failure is already swallowed by `try/catch`).

## Out of scope

- The `tests/pi-runtime.test.ts` / `tests/pi-web-access.test.ts` POSIX-path expectations are a separate Windows-CI concern and would dilute this focused fix.
