### PR TITLE
feat: add MiniMax-M3 to research model preferences

### DIFF
--- a/src/model/catalog.ts
+++ b/src/model/catalog.ts
@@ -109,6 +109,10 @@ const RESEARCH_MODEL_PREFERENCES = [
 		reason: "good fallback when GLM is the available research model",
 	},
 	{
+		spec: "minimax/MiniMax-M3",
+		reason: "latest MiniMax model with 512K context and image input for research work",
+	},
+	{
 		spec: "minimax/MiniMax-M2.7",
 		reason: "good fallback when MiniMax is the available research model",
 	},


### PR DESCRIPTION
## Summary

- Add `minimax/MiniMax-M3` above the existing `M2.7` entries in `RESEARCH_MODEL_PREFERENCES` in `src/model/catalog.ts`, so Feynman recommends `MiniMax-M3` for research work whenever Pi exposes it
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as fallbacks
- No other behavior change: model registry, env-var setup, and provider sort order are unchanged

## Why

`MiniMax-M3` is the latest MiniMax model with a 512K context window, up to 128K max output, and image input support. Listing it in the research preference order ahead of M2.7 means Feynman will surface M3 as the recommendation as soon as Pi's catalog ships it, with no further code change needed.

Because Pi 0.73.x still only exposes `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` for the `minimax` provider, this preference entry is a no-op at runtime today and intentionally falls through to M2.7 in `chooseRecommendedModel`. That preserves the existing `MiniMax M2.7 over highspeed` test expectation.

## Testing

- `git diff` shows the change is a pure preference-array addition (no logic edits).
- The single existing MiniMax test (`chooseRecommendedModel prefers MiniMax M2.7 over highspeed when that is the authenticated provider`) continues to assert `minimax/MiniMax-M2.7`, which is correct given Pi's current registry.