### PR TITLE
fix: resolve npm alias specs for legacy Pi runtime peers found in node_modules

### DIFF
--- a/src/pi/package-ops.ts
+++ b/src/pi/package-ops.ts
@@ -168,22 +168,26 @@ function isPiRuntimePackageName(packageName: string): boolean {
 	return packageName.startsWith("pi-") || packageName.includes("/pi-");
 }
 
-function readInstalledPackageVersion(packageRoot: string): string | undefined {
-	try {
-		const pkg = JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf8")) as { version?: unknown };
-		return typeof pkg.version === "string" ? pkg.version : undefined;
-	} catch {
-		return undefined;
-	}
-}
-
 function resolveRuntimePeerSpec(packageName: string): string | undefined {
 	for (const packageRoot of [
 		resolve(APP_ROOT, "node_modules", packageName),
 		resolve(APP_ROOT, ".feynman", "npm", "node_modules", packageName),
 	]) {
-		const version = readInstalledPackageVersion(packageRoot);
-		if (version) return `${packageName}@${version}`;
+		try {
+			const pkg = JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf8")) as {
+				name?: unknown;
+				version?: unknown;
+			};
+			const version = typeof pkg.version === "string" ? pkg.version : undefined;
+			if (!version) continue;
+			const pkgName = typeof pkg.name === "string" ? pkg.name : undefined;
+			if (pkgName && pkgName !== packageName) {
+				return `${packageName}@npm:${pkgName}@${version}`;
+			}
+			return `${packageName}@${version}`;
+		} catch {
+			continue;
+		}
 	}
 
 	const aliasTarget = LEGACY_PI_RUNTIME_PACKAGE_ALIASES[packageName as keyof typeof LEGACY_PI_RUNTIME_PACKAGE_ALIASES];

--- a/tests/package-ops.test.ts
+++ b/tests/package-ops.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { appendFileSync, cpSync, existsSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { appendFileSync, cpSync, existsSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -345,9 +345,11 @@ test("installPackageSources installs Pi runtime peers beside Pi packages", async
 	const invocations = readFileSync(logPath, "utf8").trim().split("\n").map((line) => JSON.parse(line) as string[]);
 	assert.equal(invocations.length, 1);
 	assert.ok(invocations[0]?.includes("pi-btw"));
-	assert.ok(invocations[0]?.some((entry) => /^@mariozechner\/pi-coding-agent@/.test(entry)));
-	assert.ok(invocations[0]?.some((entry) => /^@mariozechner\/pi-ai@/.test(entry)));
-	assert.ok(invocations[0]?.some((entry) => /^@mariozechner\/pi-tui@/.test(entry)));
+	assert.ok(invocations[0]?.some((entry) => /^@mariozechner\/pi-agent-core@npm:@earendil-works\/pi-agent-core@/.test(entry)));
+	assert.ok(invocations[0]?.some((entry) => /^@mariozechner\/pi-coding-agent@npm:@earendil-works\/pi-coding-agent@/.test(entry)));
+	assert.ok(invocations[0]?.some((entry) => /^@mariozechner\/pi-ai@npm:@earendil-works\/pi-ai@/.test(entry)));
+	assert.ok(invocations[0]?.some((entry) => /^@mariozechner\/pi-tui@npm:@earendil-works\/pi-tui@/.test(entry)));
+	assert.ok(invocations[0]?.some((entry) => /^@earendil-works\/pi-agent-core@/.test(entry)));
 	assert.ok(invocations[0]?.some((entry) => /^@earendil-works\/pi-coding-agent@/.test(entry)));
 	assert.ok(invocations[0]?.some((entry) => /^@earendil-works\/pi-ai@/.test(entry)));
 	assert.ok(invocations[0]?.some((entry) => /^@earendil-works\/pi-tui@/.test(entry)));
@@ -495,4 +497,66 @@ test("updateConfiguredPackages skips native package updates on unsupported Node 
 	assert.equal(invocations.length, 1);
 	assert.ok(invocations[0]?.includes("test-regular@latest"));
 	assert.ok(!invocations[0]?.some((entry) => entry.includes("pi-session-search")));
+});
+
+test("installPackageSources emits npm alias specs for legacy Pi runtime peers found in node_modules", async () => {
+	const root = mkdtempSync(join(tmpdir(), "feynman-package-ops-"));
+	const workingDir = resolve(root, "project");
+	const agentDir = resolve(root, "agent");
+	const logPath = resolve(root, "npm-invocations.jsonl");
+	mkdirSync(workingDir, { recursive: true });
+
+	const scriptPath = writeFakeNpmScript(root, [
+		`import { appendFileSync } from "node:fs";`,
+		`appendFileSync(${JSON.stringify(logPath)}, JSON.stringify(process.argv.slice(2)) + "\\n", "utf8");`,
+		"process.exit(0);",
+	].join("\n"));
+
+	writeSettings(agentDir, {
+		npmCommand: [process.execPath, scriptPath],
+	});
+
+	// Simulate the standalone bundle layout: legacy-scope directories whose
+	// package.json name field points at the current @earendil-works scope.
+	const appRoot = resolve(import.meta.dirname ?? __dirname, "..");
+	const bundledRoot = resolve(appRoot, ".feynman", "npm", "node_modules");
+	const legacyPackages = {
+		"@mariozechner/pi-agent-core": "@earendil-works/pi-agent-core",
+		"@mariozechner/pi-coding-agent": "@earendil-works/pi-coding-agent",
+		"@mariozechner/pi-ai": "@earendil-works/pi-ai",
+		"@mariozechner/pi-tui": "@earendil-works/pi-tui",
+	};
+
+	const createdPaths: string[] = [];
+	try {
+		for (const [dirName, realName] of Object.entries(legacyPackages)) {
+			const pkgDir = resolve(bundledRoot, dirName);
+			mkdirSync(pkgDir, { recursive: true });
+			createdPaths.push(pkgDir);
+			writeFileSync(
+				resolve(pkgDir, "package.json"),
+				JSON.stringify({ name: realName, version: "0.79.1" }, null, 2) + "\n",
+				"utf8",
+			);
+		}
+
+		const result = await installPackageSources(workingDir, agentDir, ["npm:pi-btw"]);
+
+		assert.deepEqual(result.installed, ["npm:pi-btw"]);
+		const invocations = readFileSync(logPath, "utf8").trim().split("\n").map((line) => JSON.parse(line) as string[]);
+		assert.equal(invocations.length, 1);
+
+		// When found in node_modules with a mismatched name, the spec must use
+		// the npm: alias form so the registry can resolve it.
+		assert.ok(invocations[0]?.some((entry) => /^@mariozechner\/pi-agent-core@npm:@earendil-works\/pi-agent-core@0\.79\.1$/.test(entry)));
+		assert.ok(invocations[0]?.some((entry) => /^@mariozechner\/pi-coding-agent@npm:@earendil-works\/pi-coding-agent@0\.79\.1$/.test(entry)));
+		assert.ok(invocations[0]?.some((entry) => /^@mariozechner\/pi-ai@npm:@earendil-works\/pi-ai@0\.79\.1$/.test(entry)));
+		assert.ok(invocations[0]?.some((entry) => /^@mariozechner\/pi-tui@npm:@earendil-works\/pi-tui@0\.79\.1$/.test(entry)));
+	} finally {
+		for (const pkgDir of createdPaths) {
+			rmSync(pkgDir, { recursive: true, force: true });
+		}
+		const scopeDir = resolve(bundledRoot, "@mariozechner");
+		try { rmSync(scopeDir, { recursive: true, force: true }); } catch {}
+	}
 });


### PR DESCRIPTION
Fixes #180.

## Problem

When `feynman update` runs on a standalone bundle, `resolveRuntimePeerSpec` finds legacy-scope Pi runtime packages (`@mariozechner/pi-*`) in `node_modules`. It reads the version from `package.json` but ignores the `name` field, which points to `@earendil-works/pi-*`. The returned spec `@mariozechner/pi-agent-core@0.79.1` can't be resolved on the npm registry, so npm exits with `ETARGET`.

The alias branch lower in the function already does the right thing — it just never runs because the `node_modules` lookup short-circuits first.

## Fix

In `resolveRuntimePeerSpec`, when a package is found in `node_modules`, also read the `name` field from `package.json`. If it differs from the directory name (the legacy alias pattern), emit the npm alias form: `@mariozechner/pi-agent-core@npm:@earendil-works/pi-agent-core@0.79.1`.

## Changes

- **src/pi/package-ops.ts**: Inlined `readInstalledPackageVersion` into `resolveRuntimePeerSpec` with name-mismatch detection; removed the now-unused helper.
- **tests/package-ops.test.ts**: Tightened existing peer-spec test to assert the exact `npm:` alias format for all four legacy packages. Added a new test that creates mock alias directories in `.feynman/npm/node_modules` and verifies the alias specs are emitted correctly.