### PR TITLE
cli: hint at feynman help on unrecognized flags

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -867,48 +867,61 @@ async function runMain(input: { here: string; appRoot: string; feynmanVersion: s
 		return;
 	}
 
-	const { values, positionals } = parseArgs({
-		args: process.argv.slice(2),
-		allowPositionals: true,
-		options: {
-			cwd: { type: "string" },
-			doctor: { type: "boolean" },
-			help: { type: "boolean" },
-			version: { type: "boolean" },
-			"alpha-login": { type: "boolean" },
-			"alpha-logout": { type: "boolean" },
-			"alpha-status": { type: "boolean" },
-			mode: { type: "string" },
-			model: { type: "string" },
-			"new-session": { type: "boolean" },
-			json: { type: "boolean" },
-			host: { type: "string" },
-			limit: { type: "string" },
-			"no-auth": { type: "boolean" },
-			"no-open": { type: "boolean" },
-			"expand-citations": { type: "string" },
-			"full-text-top": { type: "string" },
-			port: { type: "string" },
-			"critique-top": { type: "string" },
-			synthesize: { type: "boolean" },
-			"synthesis-top": { type: "string" },
-			"synthesis-model": { type: "string" },
-			"output-dir": { type: "string" },
-			"fetch-full-text": { type: "boolean" },
-			"preference-file": { type: "string" },
-			"reproduction-notes": { type: "string" },
-			prompt: { type: "string" },
-			"service-tier": { type: "string" },
-			"session-dir": { type: "string" },
-			"source-fixture": { type: "string" },
-			"setup-preview": { type: "boolean" },
-			"tier1-threshold": { type: "string" },
-			"tier2-threshold": { type: "string" },
-			thinking: { type: "string" },
-			overlap: { type: "string" },
-			"window-size": { type: "string" },
-		},
-	});
+	const parseCliArgs = () =>
+		parseArgs({
+			args: process.argv.slice(2),
+			allowPositionals: true,
+			options: {
+				cwd: { type: "string" },
+				doctor: { type: "boolean" },
+				help: { type: "boolean" },
+				version: { type: "boolean" },
+				"alpha-login": { type: "boolean" },
+				"alpha-logout": { type: "boolean" },
+				"alpha-status": { type: "boolean" },
+				mode: { type: "string" },
+				model: { type: "string" },
+				"new-session": { type: "boolean" },
+				json: { type: "boolean" },
+				host: { type: "string" },
+				limit: { type: "string" },
+				"no-auth": { type: "boolean" },
+				"no-open": { type: "boolean" },
+				"expand-citations": { type: "string" },
+				"full-text-top": { type: "string" },
+				port: { type: "string" },
+				"critique-top": { type: "string" },
+				synthesize: { type: "boolean" },
+				"synthesis-top": { type: "string" },
+				"synthesis-model": { type: "string" },
+				"output-dir": { type: "string" },
+				"fetch-full-text": { type: "boolean" },
+				"preference-file": { type: "string" },
+				"reproduction-notes": { type: "string" },
+				prompt: { type: "string" },
+				"service-tier": { type: "string" },
+				"session-dir": { type: "string" },
+				"source-fixture": { type: "string" },
+				"setup-preview": { type: "boolean" },
+				"tier1-threshold": { type: "string" },
+				"tier2-threshold": { type: "string" },
+				thinking: { type: "string" },
+				overlap: { type: "string" },
+				"window-size": { type: "string" },
+			},
+		});
+
+	let parsedArgs: ReturnType<typeof parseCliArgs>;
+	try {
+		parsedArgs = parseCliArgs();
+	} catch (error) {
+		if (error && typeof error === "object" && "code" in error && error.code === "ERR_PARSE_ARGS_UNKNOWN_OPTION") {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new Error(`${message}\nRun \`feynman help\` to see available commands and flags.`);
+		}
+		throw error;
+	}
+	const { values, positionals } = parsedArgs;
 
 	if (values.help) {
 		printHelp(appRoot);


### PR DESCRIPTION
## Summary

Fixes #187. `node:util`'s `parseArgs` (strict mode) throws a bare `Unknown option '--x'` error for any unrecognized flag, anywhere in the CLI, with no pointer to `feynman help`. This is especially confusing for a command like `feynman update`, which only documents an optional `[package]` positional and has no flags of its own — the error gives no hint that the flag doesn't exist or where to look next.

This wraps the top-level `parseArgs` call in `runMain` and, specifically for `ERR_PARSE_ARGS_UNKNOWN_OPTION`, appends a one-line hint to run `feynman help`.

Before:
```
$ feynman update --extensions
Unknown option '--extensions'. To specify a positional argument starting with a '-', place it at the end of the command after '--', as in '-- "--extensions"'
```

After:
```
$ feynman update --extensions
Unknown option '--extensions'. To specify a positional argument starting with a '-', place it at the end of the command after '--', as in '-- "--extensions"'
Run `feynman help` to see available commands and flags.
```

No behavior change for recognized flags/commands.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` — 585/585 tests pass
- [x] Manually verified `feynman update --extensions` now prints the hint and exits 1
- [x] Manually verified `feynman --help` and `feynman --version` still work unchanged