### PR TITLE
[codex] Fix stale bundled package link pruning

### DIFF
--- a/src/pi/package-ops.ts
+++ b/src/pi/package-ops.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, readlinkSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, readlinkSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
@@ -624,7 +624,7 @@ function pruneStaleBundledPackageLinks(
 			continue;
 		}
 
-		rmSync(packagePath, { force: true });
+		unlinkSync(packagePath);
 		removeEmptyScopeDirectory(packagePath, packageName, globalNodeModulesRoot);
 	}
 }


### PR DESCRIPTION
## Summary

- remove stale bundled-package symlinks with `unlinkSync`
- allow the existing empty-scope cleanup to remove the now-empty npm scope directory

## Why

On Node 25/macOS, `rmSync(path, { force: true })` treats a dangling directory symlink as absent and leaves the directory entry behind. `seedBundledWorkspacePackages` therefore fails to prune links to packages removed from a newer bundled runtime, and the empty scope directory remains.

`unlinkSync` operates on the symlink entry itself, including when its target no longer exists.

## Verification

- Existing regression test failed on `main`: `seedBundledWorkspacePackages prunes stale links from previous bundled runtimes` (`true !== false` at `tests/package-seeding.test.ts:226`).
- The targeted test passes with this change.
- `npm test` passed.
- `npm run typecheck` passed.
- `npm run build` passed with existing third-party bundle warnings.
- `npm run architecture:check` passed with the repository's recorded split-debt warnings.
- A minimal end-to-end driver created a dangling `@opentelemetry/api` link, invoked `seedBundledWorkspacePackages`, and observed `staleAfter:false` and `scopeAfter:false` while still seeding `npm:pi-subagents`.
- `node dist/index.js --help` exited 0.
