### PR TITLE
Add Atlas Cloud model provider setup

### DIFF
--- a/src/model/api-key-providers.ts
+++ b/src/model/api-key-providers.ts
@@ -5,6 +5,7 @@ export type ApiKeyProviderInfo = {
 };
 
 export const MODEL_API_KEY_PROVIDERS: ApiKeyProviderInfo[] = [
+	{ id: "atlascloud", label: "Atlas Cloud (OpenAI-compatible)", envVar: "ATLASCLOUD_API_KEY" },
 	{ id: "openai", label: "OpenAI Platform API", envVar: "OPENAI_API_KEY" },
 	{ id: "anthropic", label: "Anthropic API", envVar: "ANTHROPIC_API_KEY" },
 	{ id: "google", label: "Google Gemini API", envVar: "GEMINI_API_KEY" },

--- a/src/model/catalog.ts
+++ b/src/model/catalog.ts
@@ -33,6 +33,7 @@ export type ModelStatusSnapshot = {
 };
 
 const PROVIDER_LABELS: Record<string, string> = {
+	atlascloud: "Atlas Cloud",
 	anthropic: "Anthropic",
 	openai: "OpenAI",
 	"openai-codex": "OpenAI Codex",
@@ -122,6 +123,7 @@ const RESEARCH_MODEL_FALLBACK_PREFERENCES: ResearchModelPreference[] = [
 ];
 
 const PROVIDER_SORT_ORDER = [
+	"atlascloud",
 	"anthropic",
 	"openai",
 	"openai-codex",

--- a/src/model/commands.ts
+++ b/src/model/commands.ts
@@ -143,6 +143,15 @@ type CustomProviderSetup = {
 	authHeader: boolean;
 };
 
+export const ATLASCLOUD_PROVIDER_CONFIG = {
+	providerId: "atlascloud",
+	baseUrl: "https://api.atlascloud.ai/v1",
+	api: "openai-completions",
+	apiKeyConfig: "ATLASCLOUD_API_KEY",
+	authHeader: true,
+	modelIds: ["qwen/qwen3.5-flash", "deepseek-ai/deepseek-v4-pro"],
+} as const;
+
 function normalizeProviderId(value: string): string {
 	return value.trim().toLowerCase().replace(/\s+/g, "-");
 }
@@ -464,6 +473,17 @@ async function promptLiteLlmProviderSetup(): Promise<CustomProviderSetup | undef
 	};
 }
 
+export function getAtlasCloudProviderSetup(): CustomProviderSetup {
+	return {
+		providerId: ATLASCLOUD_PROVIDER_CONFIG.providerId,
+		modelIds: [...ATLASCLOUD_PROVIDER_CONFIG.modelIds],
+		baseUrl: ATLASCLOUD_PROVIDER_CONFIG.baseUrl,
+		api: ATLASCLOUD_PROVIDER_CONFIG.api,
+		apiKeyConfig: ATLASCLOUD_PROVIDER_CONFIG.apiKeyConfig,
+		authHeader: ATLASCLOUD_PROVIDER_CONFIG.authHeader,
+	};
+}
+
 async function verifyCustomProvider(setup: CustomProviderSetup, authPath: string): Promise<void> {
 	const registry = createModelRegistry(authPath);
 	const modelsError = registry.getError();
@@ -696,6 +716,27 @@ async function configureApiKeyProvider(authPath: string, providerId?: string): P
 		}
 
 		printSuccess("Saved LiteLLM provider.");
+		await verifyCustomProvider(setup, authPath);
+		return true;
+	}
+
+	if (provider.id === "atlascloud") {
+		const setup = getAtlasCloudProviderSetup();
+		const modelsJsonPath = getModelsJsonPath(authPath);
+		const result = upsertProviderConfig(modelsJsonPath, setup.providerId, {
+			baseUrl: setup.baseUrl,
+			apiKey: setup.apiKeyConfig,
+			api: setup.api,
+			authHeader: setup.authHeader,
+			models: setup.modelIds.map((id) => ({ id })),
+		});
+		if (!result.ok) {
+			printWarning(result.error);
+			return false;
+		}
+
+		printSuccess("Saved Atlas Cloud provider.");
+		printInfo("Set ATLASCLOUD_API_KEY in your shell or .env before using Feynman.");
 		await verifyCustomProvider(setup, authPath);
 		return true;
 	}

--- a/tests/models-json.test.ts
+++ b/tests/models-json.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { ATLASCLOUD_PROVIDER_CONFIG, getAtlasCloudProviderSetup } from "../src/model/commands.js";
 import { upsertProviderConfig } from "../src/model/models-json.js";
 
 test("upsertProviderConfig creates models.json and merges provider config", () => {
@@ -71,6 +72,38 @@ test("upsertProviderConfig writes LiteLLM proxy config without master key", () =
 	assert.equal(parsed.providers.litellm.api, "openai-completions");
 	assert.equal(parsed.providers.litellm.authHeader, false);
 	assert.deepEqual(parsed.providers.litellm.models, [{ id: "llama3" }]);
+});
+
+test("Atlas Cloud setup maps to OpenAI-compatible provider config", () => {
+	const setup = getAtlasCloudProviderSetup();
+	assert.equal(setup.providerId, "atlascloud");
+	assert.equal(setup.baseUrl, "https://api.atlascloud.ai/v1");
+	assert.equal(setup.api, "openai-completions");
+	assert.equal(setup.apiKeyConfig, "ATLASCLOUD_API_KEY");
+	assert.equal(setup.authHeader, true);
+	assert.deepEqual(setup.modelIds, [...ATLASCLOUD_PROVIDER_CONFIG.modelIds]);
+
+	const dir = mkdtempSync(join(tmpdir(), "feynman-atlascloud-"));
+	const modelsPath = join(dir, "models.json");
+
+	const result = upsertProviderConfig(modelsPath, setup.providerId, {
+		baseUrl: setup.baseUrl,
+		apiKey: setup.apiKeyConfig,
+		api: setup.api,
+		authHeader: setup.authHeader,
+		models: setup.modelIds.map((id) => ({ id })),
+	});
+	assert.deepEqual(result, { ok: true });
+
+	const parsed = JSON.parse(readFileSync(modelsPath, "utf8")) as any;
+	assert.equal(parsed.providers.atlascloud.baseUrl, "https://api.atlascloud.ai/v1");
+	assert.equal(parsed.providers.atlascloud.apiKey, "ATLASCLOUD_API_KEY");
+	assert.equal(parsed.providers.atlascloud.api, "openai-completions");
+	assert.equal(parsed.providers.atlascloud.authHeader, true);
+	assert.deepEqual(parsed.providers.atlascloud.models, [
+		{ id: "qwen/qwen3.5-flash" },
+		{ id: "deepseek-ai/deepseek-v4-pro" },
+	]);
 });
 
 test("upsertProviderConfig rejects provider ids with path traversal chars", () => {


### PR DESCRIPTION
## Summary
- add Atlas Cloud to Feynman's API-key model provider setup list
- write Atlas Cloud as an OpenAI-compatible provider in models.json with `ATLASCLOUD_API_KEY`, `https://api.atlascloud.ai/v1`, and live-verified model ids
- include focused coverage for the generated Atlas Cloud provider config

## Validation
- `node --import tsx --test --test-concurrency=1 tests/models-json.test.ts tests/catalog-snapshot.test.ts` (passed on the pre-rebase branch)
- `npm run typecheck` (passed on the pre-rebase branch)
- `npm run build` (passed on the pre-rebase branch)
- `git diff --check`
- Atlas Cloud live `/v1/models` check returned 118 models and included `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`
- Rebased the PR branch onto current upstream `main` via GitHub Git API after local `git fetch`/tarball downloads timed out; updated files were syntax-checked with the TypeScript compiler API

No README changes; no sponsor, logo, credits, or partner placement added.