### PR TITLE
Add /thinking REPL command

### DIFF
--- a/extensions/research-tools.ts
+++ b/extensions/research-tools.ts
@@ -10,6 +10,7 @@ import { registerHuggingFaceTools } from "./research-tools/huggingface.js";
 import { registerInitCommand, registerOutputsCommand } from "./research-tools/project.js";
 import { registerServiceTierControls } from "./research-tools/service-tier.js";
 import { registerScienceDatabaseTools } from "./research-tools/science-databases.js";
+import { registerThinkingCommand } from "./research-tools/thinking.js";
 import { registerModelEndpointTools } from "./research-tools/model-endpoints.js";
 import { registerWorkbenchConnectorTools } from "./research-tools/workbench-connectors.js";
 import { registerWorkbenchContextTool } from "./research-tools/workbench-context.js";
@@ -31,6 +32,7 @@ export default function researchTools(pi: ExtensionAPI): void {
 	registerInitCommand(pi);
 	registerOutputsCommand(pi);
 	registerServiceTierControls(pi);
+	registerThinkingCommand(pi);
 	registerScienceDatabaseTools(pi);
 	registerModelEndpointTools(pi);
 	registerWorkbenchConnectorTools(pi);

--- a/extensions/research-tools/thinking.ts
+++ b/extensions/research-tools/thinking.ts
@@ -1,0 +1,58 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const thinkingLevels = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+
+type ThinkingLevel = (typeof thinkingLevels)[number];
+
+function parseThinkingLevel(value: string): ThinkingLevel | undefined {
+	const normalized = value.trim().toLowerCase();
+	return thinkingLevels.find((level) => level === normalized);
+}
+
+function setThinkingLevel(
+	pi: ExtensionAPI,
+	ctx: { ui: { notify: (message: string, level: "info" | "error") => void } },
+	level: ThinkingLevel,
+): void {
+	pi.setThinkingLevel(level);
+	ctx.ui.notify(`Thinking level set to ${pi.getThinkingLevel()}.`, "info");
+}
+
+export function registerThinkingCommand(pi: ExtensionAPI): void {
+	pi.registerCommand("thinking", {
+		description: "View or set the current thinking level.",
+		handler: async (args, ctx) => {
+			if (!ctx.hasUI) {
+				ctx.ui.notify("thinking requires interactive mode.", "error");
+				return;
+			}
+
+			const requestedLevel = args.trim();
+			if (requestedLevel) {
+				const level = parseThinkingLevel(requestedLevel);
+				if (!level) {
+					ctx.ui.notify(
+						`Unknown thinking level "${requestedLevel}". Available: ${thinkingLevels.join(", ")}.`,
+						"error",
+					);
+					return;
+				}
+				setThinkingLevel(pi, ctx, level);
+				return;
+			}
+
+			const currentLevel = pi.getThinkingLevel();
+			const options = thinkingLevels.map((level) => ({
+				label: level === currentLevel ? `${level} (current)` : level,
+				level,
+			}));
+			const selected = await ctx.ui.select(
+				`Thinking level: ${currentLevel}`,
+				options.map((option) => option.label),
+			);
+			const level = options.find((option) => option.label === selected)?.level;
+			if (!level) return;
+			setThinkingLevel(pi, ctx, level);
+		},
+	});
+}

--- a/metadata/commands.mjs
+++ b/metadata/commands.mjs
@@ -42,6 +42,7 @@ export const extensionCommandSpecs = [
 	{ name: "init", args: "", section: "Project & Session", description: "Bootstrap AGENTS.md and session-log folders for a research project.", publicDocs: true },
 	{ name: "outputs", args: "", section: "Project & Session", description: "Browse all research artifacts (papers, outputs, experiments, notes).", publicDocs: true },
 	{ name: "service-tier", args: "", section: "Project & Session", description: "View or set the provider service tier override for supported models.", publicDocs: true },
+	{ name: "thinking", args: "[level]", section: "Project & Session", description: "View or set the current thinking level.", publicDocs: true },
 	{ name: "tools", args: "", section: "Project & Session", description: "Browse public research tools with their source and parameter summary.", publicDocs: true },
 ];
 

--- a/tests/help-command.test.ts
+++ b/tests/help-command.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import { registerDiscoveryCommands } from "../extensions/research-tools/discovery.js";
 import { registerHelpCommand } from "../extensions/research-tools/help.js";
+import { registerThinkingCommand } from "../extensions/research-tools/thinking.js";
 
 test("Feynman help omits generic scheduler and process package commands", async () => {
 	const registered = new Map<string, { handler: (_args: string[], ctx: unknown) => Promise<void> }>();
@@ -41,6 +42,7 @@ test("Feynman help omits generic scheduler and process package commands", async 
 		},
 	};
 
+	registerThinkingCommand(pi as any);
 	registerHelpCommand(pi as any);
 	await registered.get("help")?.handler([], ctx);
 
@@ -48,6 +50,7 @@ test("Feynman help omits generic scheduler and process package commands", async 
 	assert.ok(helpItems.some((item) => item.startsWith("/search ")));
 	assert.ok(helpItems.some((item) => item.startsWith("/preview ")));
 	assert.ok(helpItems.some((item) => item.startsWith("/hotkeys ")));
+	assert.ok(helpItems.some((item) => item.startsWith("/thinking [level]")));
 	assert.equal(helpItems.some((item) => item.startsWith("/ps ")), false);
 	assert.equal(helpItems.some((item) => item.startsWith("/schedule-prompt ")), false);
 });

--- a/tests/thinking-command.test.ts
+++ b/tests/thinking-command.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { registerThinkingCommand } from "../extensions/research-tools/thinking.js";
+
+type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+
+type RegisteredCommand = {
+	description?: string;
+	handler: (args: string, ctx: unknown) => Promise<void>;
+};
+
+function createCommandFixture(initialLevel: ThinkingLevel, selected?: string) {
+	const registered = new Map<string, RegisteredCommand>();
+	const notifications: Array<{ message: string; level: string }> = [];
+	const selections: Array<{ title: string; items: string[] }> = [];
+	let thinkingLevel = initialLevel;
+
+	const pi = {
+		getThinkingLevel: () => thinkingLevel,
+		setThinkingLevel: (level: ThinkingLevel) => {
+			thinkingLevel = level;
+		},
+		registerCommand: (name: string, command: RegisteredCommand) => {
+			registered.set(name, command);
+		},
+	};
+	const ctx = {
+		hasUI: true,
+		ui: {
+			select: async (title: string, items: string[]) => {
+				selections.push({ title, items });
+				return selected;
+			},
+			notify: (message: string, level: string) => {
+				notifications.push({ message, level });
+			},
+		},
+	};
+
+	registerThinkingCommand(pi as any);
+	const command = registered.get("thinking");
+	assert.ok(command);
+
+	return {
+		command,
+		ctx,
+		getThinkingLevel: () => thinkingLevel,
+		notifications,
+		selections,
+	};
+}
+
+test("/thinking directly sets a valid thinking level", async () => {
+	const fixture = createCommandFixture("medium");
+
+	await fixture.command.handler(" high ", fixture.ctx);
+
+	assert.equal(fixture.getThinkingLevel(), "high");
+	assert.deepEqual(fixture.selections, []);
+	assert.deepEqual(fixture.notifications, [{ message: "Thinking level set to high.", level: "info" }]);
+});
+
+test("/thinking shows the current level in its picker", async () => {
+	const fixture = createCommandFixture("medium", "xhigh");
+
+	await fixture.command.handler("", fixture.ctx);
+
+	assert.equal(fixture.getThinkingLevel(), "xhigh");
+	assert.deepEqual(fixture.selections, [
+		{
+			title: "Thinking level: medium",
+			items: ["off", "minimal", "low", "medium (current)", "high", "xhigh"],
+		},
+	]);
+	assert.deepEqual(fixture.notifications, [{ message: "Thinking level set to xhigh.", level: "info" }]);
+});
+
+test("/thinking rejects an unknown thinking level", async () => {
+	const fixture = createCommandFixture("medium");
+
+	await fixture.command.handler("maximum", fixture.ctx);
+
+	assert.equal(fixture.getThinkingLevel(), "medium");
+	assert.deepEqual(fixture.selections, []);
+	assert.deepEqual(fixture.notifications, [
+		{
+			message: 'Unknown thinking level "maximum". Available: off, minimal, low, medium, high, xhigh.',
+			level: "error",
+		},
+	]);
+});

--- a/website/src/content/docs/reference/slash-commands.md
+++ b/website/src/content/docs/reference/slash-commands.md
@@ -32,6 +32,7 @@ These are the primary commands you use during research runs. Workflow prompts ca
 | `/jobs` | Inspect visible research-run process/scheduler state and durable watch or experiment artifacts |
 | `/help` | Show grouped Feynman commands and prefill the editor with a selected command |
 | `/feynman-model` | Open the non-Pro model picker for the main default model and per-subagent overrides |
+| `/thinking [level]` | Show the current thinking level and choose one, or set `off`, `minimal`, `low`, `medium`, `high`, or `xhigh` directly; `Shift+Tab` still cycles levels |
 | `/init` | Bootstrap `AGENTS.md` and session-log folders for a new research project |
 | `/outputs` | Browse all research artifacts (papers, outputs, experiments, notes) |
 | `/btw <question>` | Ask a side question while the main research agent is busy and hand the result back when needed |


### PR DESCRIPTION
## Summary

- add `/thinking` as a discoverable REPL command for viewing and changing the current thinking level
- open a picker with the current level marked when no argument is provided
- accept `off`, `minimal`, `low`, `medium`, `high`, or `xhigh` directly
- preserve the existing `Shift+Tab` cycle behavior

Fixes #196

## Validation

- `node --import tsx --test tests/thinking-command.test.ts tests/help-command.test.ts` — 6 passed
- `npm test` — 588 passed
- `npm run typecheck`
- `npm run build`
- `cd website && npm run build` — 34 pages built

## AI-assisted contribution

This change was prepared with AI assistance. I reviewed the final diff, verified it against the installed Pi extension API, and ran the checks listed above.
