### PR TITLE
Fix stale Pi package failures on upgrade

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -240,6 +240,7 @@ jobs:
           "$bin" --help >/dev/null
           HOME="$RUNNER_TEMP/feynman-home" FEYNMAN_HOME="$RUNNER_TEMP/feynman-home" "$bin" packages list
           HOME="$RUNNER_TEMP/feynman-home" FEYNMAN_HOME="$RUNNER_TEMP/feynman-home" "$bin" search status
+          node scripts/verify-stale-pi-upgrade.mjs "$bin"
           node "$consumer/node_modules/@companion-ai/feynman/scripts/verify-package-artifact.mjs" \
             "$consumer/node_modules/@companion-ai/feynman"
           test -z "$(git status --porcelain --untracked-files=all)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -272,6 +272,7 @@ jobs:
           "$bin" --help >/dev/null
           HOME="$RUNNER_TEMP/feynman-home" FEYNMAN_HOME="$RUNNER_TEMP/feynman-home" "$bin" packages list
           HOME="$RUNNER_TEMP/feynman-home" FEYNMAN_HOME="$RUNNER_TEMP/feynman-home" "$bin" search status
+          node scripts/verify-stale-pi-upgrade.mjs "$bin"
           runtime_audit="$RUNNER_TEMP/feynman-runtime-audit"
           mkdir -p "$runtime_audit"
           runtime_archive="$consumer/node_modules/@companion-ai/feynman/.feynman/runtime-workspace.tgz"
@@ -484,6 +485,7 @@ jobs:
           tar -xzf "dist/release/feynman-${VERSION}-${{ matrix.id }}.tar.gz" -C "$tmp"
           "$tmp/feynman-${VERSION}-${{ matrix.id }}/feynman" --help >/tmp/feynman-help.out
           head -20 /tmp/feynman-help.out
+          node scripts/verify-stale-pi-upgrade.mjs "$tmp/feynman-${VERSION}-${{ matrix.id }}/feynman"
       - name: Smoke native bundle (Windows)
         if: matrix.id == 'win32-x64'
         shell: pwsh
@@ -496,6 +498,10 @@ jobs:
           & (Join-Path $bundleRoot "feynman.cmd") --help | Select-Object -First 20
           if ($LASTEXITCODE -ne 0) {
             throw "Windows native launcher failed --help: $LASTEXITCODE"
+          }
+          node scripts/verify-stale-pi-upgrade.mjs (Join-Path $bundleRoot "feynman.cmd")
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows native launcher failed stale-Pi upgrade smoke: $LASTEXITCODE"
           }
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Workspace lab notebook for long-running or resumable research work.
 
 Use this file to track chronology, not release notes. Keep entries short, factual, and operational.
 
+### 2026-07-28 21:20 PDT — intake-sweep-stale-pi-editor-upgrade
+
+- Objective: Reproduce and fix issue `#202`, where a standalone `0.3.7` install failed at launch with `Unsupported Pi editor layout: required import patch anchor was not found`.
+- Found: Pi stores user packages under `<agentDir>/npm`. An upgrade can retain Pi `0.80.6` core dependencies there. The exact published `0.3.7` RPC launch failed against the official stale editor, and a one-anchor editor compatibility patch then failed against the same release's ModelRegistry. Pi `0.82.1` already aliases extension peer imports to the current bundled core, so patching each historical core layout is unnecessary and brittle.
+- Fixed: Resolve Feynman's bundled Pi version from package metadata and skip core patchers only for Pi packages with a different explicit version. Security, MCP, and extension patching still covers user roots. Package and native release gates now launch twice with staged stale editor and ModelRegistry files, prove those core files remain byte-identical, and prove extension patching remains idempotent.
+- Verified locally: Fresh official Pi `0.80.6` packages passed two idempotent patch passes (`true`, then `false`) with editor and ModelRegistry hashes unchanged, followed by two clean RPC launches. Focused tests passed `22/22`; full tests passed `655/655`; typecheck, build, architecture check, actionlint, website lint/typecheck/build (`34` pages), root/website/runtime/clean-consumer audits, and `git diff --check` passed. Dry and real packs matched at `111,634,612` bytes / `39,692` entries with SHA-256 `daaf0e114b4e708269629edc99b166f782990f0940105265f6efa2dade0c1376`. The clean installed tarball passed artifact verification and the two-pass stale upgrade smoke with runtime archive SHA-256 `5dee5447b585bab835bcb3dd74b5a832a69b4e7cbea57aa4ca3d75794242d788`; the native macOS arm64 bundle passed the same smoke at SHA-256 `6db6e81d58b91a0b78d043e9532b078341aaae0bf965dfa8c65d158690c1660f`.
+- State: `verified` locally. Next: prove the exact commit in Daytona and required GitHub CI, then merge and verify the `0.3.8` npm/GitHub/native release before closing `#202`.
+
 ### 2026-07-28 14:30 PDT — intake-sweep-global-npm-install
 
 - Objective: Re-run the terminal intake after `0.3.6`, including the documented global npm install path rather than treating a clean project-prefix consumer as equivalent.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,16 @@ GitHub release notes are generated from the matching `## vX.Y.Z` section in this
 
 ## Unreleased
 
+## v0.3.8 - 2026-07-28
+
+### Reliability
+
+- Fixed standalone upgrades failing at launch with `Unsupported Pi editor layout` when an older Pi core dependency remained in the user's package directory. Startup now leaves stale Pi core copies untouched while continuing to patch installed extensions, which Pi loads against Feynman's current bundled runtime.
+
+### Validation
+
+- Added an installed-package and native-bundle upgrade smoke that stages a Pi `0.80.6` user-package tree, proves its core files remain unchanged, verifies extension patching stays idempotent, and launches Feynman through RPC twice before a release can publish.
+
 ## v0.3.7 - 2026-07-28
 
 ### Reliability

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@companion-ai/feynman",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "bundleDependencies": [
         "@companion-ai/alpha-hub",
         "@earendil-works/pi-agent-core",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Research-first CLI agent built on Pi and alphaXiv",
   "license": "MIT",
   "type": "module",

--- a/scripts/verify-stale-pi-upgrade.mjs
+++ b/scripts/verify-stale-pi-upgrade.mjs
@@ -1,0 +1,156 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+
+const binaryArgument = process.argv[2];
+if (!binaryArgument) {
+	console.error("Usage: node scripts/verify-stale-pi-upgrade.mjs <feynman-binary>");
+	process.exit(1);
+}
+const binaryPath = resolve(binaryArgument);
+
+const root = mkdtempSync(resolve(tmpdir(), "feynman-stale-pi-upgrade-"));
+const feynmanHome = resolve(root, ".feynman");
+const agentDir = resolve(feynmanHome, "agent");
+const managedNodeModulesPath = resolve(agentDir, "npm", "node_modules");
+const persistentNodeModulesPath = resolve(feynmanHome, "npm-global", "lib", "node_modules");
+const otelConfigPath = resolve(persistentNodeModulesPath, "pi-otel", "dist", "config.js");
+
+const staleEditorSource = `\
+import { cjkBreakRegex, getGraphemeSegmenter, getWordSegmenter, isWhitespaceChar, truncateToWidth, visibleWidth, } from "../utils.js";
+
+export class Editor {
+    render(width) {
+        const layoutLines = this.layoutText(width);
+        return layoutLines.map((line) => line.text);
+    }
+    handleInput(data) {
+        return data;
+    }
+}
+`;
+
+const staleModelRegistrySource = `\
+export class ModelRegistry {
+    getModel(provider, modelId) {
+        return this.models.find((model) => model.provider === provider && model.id === modelId);
+    }
+}
+`;
+
+const staleTuiManifest = `${JSON.stringify({
+	name: "@earendil-works/pi-tui",
+	version: "0.80.6",
+}, null, 2)}\n`;
+
+const staleCodingAgentManifest = `${JSON.stringify({
+	name: "@earendil-works/pi-coding-agent",
+	version: "0.80.6",
+	piConfig: { name: "pi", configDir: ".pi" },
+}, null, 2)}\n`;
+
+const otelConfigSource = `\
+    const endpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT ??
+        merged?.endpoint ??
+        "http://127.0.0.1:4317";
+    const protocol = normalizeProtocol(process.env.OTEL_EXPORTER_OTLP_PROTOCOL ?? merged?.protocol);
+    const headers = {
+        ...(merged?.headers ?? {}),
+        ...parseKvList(process.env.OTEL_EXPORTER_OTLP_HEADERS),
+    };
+`;
+
+function getStaleFiles(nodeModulesPath) {
+	const staleTuiRoot = resolve(nodeModulesPath, "@earendil-works", "pi-tui");
+	const staleCodingAgentRoot = resolve(nodeModulesPath, "@earendil-works", "pi-coding-agent");
+	return new Map([
+		[resolve(staleTuiRoot, "package.json"), staleTuiManifest],
+		[resolve(staleTuiRoot, "dist", "components", "editor.js"), staleEditorSource],
+		[resolve(staleCodingAgentRoot, "package.json"), staleCodingAgentManifest],
+		[resolve(staleCodingAgentRoot, "dist", "core", "model-registry.js"), staleModelRegistrySource],
+	]);
+}
+
+const managedStaleFiles = getStaleFiles(managedNodeModulesPath);
+const persistentStaleFiles = getStaleFiles(persistentNodeModulesPath);
+
+function writeFiles(files) {
+	for (const [path, source] of files) {
+		mkdirSync(dirname(path), { recursive: true });
+		writeFileSync(path, source, "utf8");
+	}
+}
+
+function runFeynman(pass) {
+	const result = spawnSync(binaryPath, ["--mode", "rpc"], {
+		cwd: root,
+		env: {
+			...process.env,
+			DO_NOT_TRACK: "1",
+			FEYNMAN_HOME: root,
+			HOME: root,
+		},
+		input: "",
+		encoding: "utf8",
+		shell: process.platform === "win32",
+		timeout: 120_000,
+	});
+	if (result.error) {
+		throw result.error;
+	}
+	if (result.signal) {
+		throw new Error(`Feynman stale-Pi upgrade smoke pass ${pass} exited with ${result.signal}`);
+	}
+	if (result.status !== 0) {
+		throw new Error(
+			[
+				`Feynman stale-Pi upgrade smoke pass ${pass} failed with code ${result.status ?? 1}`,
+				result.stdout?.trim(),
+				result.stderr?.trim(),
+			].filter(Boolean).join("\n"),
+		);
+	}
+}
+
+try {
+	writeFiles(managedStaleFiles);
+	writeFiles(persistentStaleFiles);
+	mkdirSync(dirname(otelConfigPath), { recursive: true });
+	writeFileSync(otelConfigPath, otelConfigSource, "utf8");
+	writeFileSync(
+		resolve(agentDir, "settings.json"),
+		JSON.stringify({ packages: [], quietStartup: true }, null, 2) + "\n",
+		"utf8",
+	);
+
+	runFeynman(1);
+
+	for (const [path, source] of persistentStaleFiles) {
+		if (readFileSync(path, "utf8") !== source) {
+			throw new Error(`Feynman modified stale Pi 0.80.6 core package file: ${path}`);
+		}
+	}
+	const patchedOtelConfig = readFileSync(otelConfigPath, "utf8");
+	for (const marker of ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "OTEL_EXPORTER_OTLP_TRACES_HEADERS"]) {
+		if (!patchedOtelConfig.includes(marker)) {
+			throw new Error(`Feynman stale-Pi upgrade smoke did not patch the extension marker: ${marker}`);
+		}
+	}
+
+	// Pi may reconcile its managed npm directory after startup. Restore the
+	// stale shape so the second launch exercises the same upgrade boundary.
+	writeFiles(managedStaleFiles);
+	runFeynman(2);
+	for (const [path, source] of persistentStaleFiles) {
+		if (readFileSync(path, "utf8") !== source) {
+			throw new Error(`Feynman modified stale Pi 0.80.6 core package file on pass 2: ${path}`);
+		}
+	}
+	if (readFileSync(otelConfigPath, "utf8") !== patchedOtelConfig) {
+		throw new Error("Feynman stale-Pi upgrade extension patch was not idempotent");
+	}
+	console.log("Feynman stale Pi 0.80.6 user-package isolation smoke passed twice.");
+} finally {
+	rmSync(root, { recursive: true, force: true });
+}

--- a/src/pi/runtime-patches.ts
+++ b/src/pi/runtime-patches.ts
@@ -42,16 +42,59 @@ function patchPackageFiles(
 	return changed;
 }
 
+function readPackageVersion(packageRoot: string): string | undefined {
+	const packageJsonPath = resolve(packageRoot, "package.json");
+	if (!existsSync(packageJsonPath)) {
+		return undefined;
+	}
+	try {
+		const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8")) as { version?: unknown };
+		return typeof pkg.version === "string" && pkg.version.length > 0 ? pkg.version : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function resolveBundledPiVersion(appRoot: string): string | undefined {
+	let fallbackVersion: string | undefined;
+	for (const nodeModulesPath of [
+		resolve(appRoot, "node_modules"),
+		resolve(appRoot, ".feynman", "npm", "node_modules"),
+	]) {
+		for (const scope of ["@earendil-works", "@mariozechner"]) {
+			const packageRoot = resolve(nodeModulesPath, scope, "pi-coding-agent");
+			const version = readPackageVersion(packageRoot);
+			if (version) {
+				fallbackVersion ??= version;
+				if (existsSync(resolve(packageRoot, "dist", "cli.js"))) {
+					return version;
+				}
+			}
+		}
+	}
+	return fallbackVersion;
+}
+
+function shouldPatchPiPackage(packageRoot: string, bundledPiVersion: string | undefined): boolean {
+	const installedVersion = readPackageVersion(packageRoot);
+	return !bundledPiVersion || !installedVersion || installedVersion === bundledPiVersion;
+}
+
 function patchScopedPiPackageFileIfPresent(
 	nodeModulesPath: string,
 	packageName: string,
 	relativePath: string,
 	patchSource: (source: string) => string,
+	bundledPiVersion: string | undefined,
 ): boolean {
 	let changed = false;
 	for (const scope of ["@earendil-works", "@mariozechner"]) {
+		const packageRoot = resolve(nodeModulesPath, scope, packageName);
+		if (!shouldPatchPiPackage(packageRoot, bundledPiVersion)) {
+			continue;
+		}
 		changed = patchFileIfPresent(
-			resolve(nodeModulesPath, scope, packageName, ...relativePath.split("/")),
+			resolve(packageRoot, ...relativePath.split("/")),
 			patchSource,
 		) || changed;
 	}
@@ -76,6 +119,7 @@ function patchPiCodingAgentPackageJsonSource(source: string): string {
 }
 
 export function patchPiRuntimeNodeModules(appRoot: string, feynmanAgentDir?: string): boolean {
+	const bundledPiVersion = resolveBundledPiVersion(appRoot);
 	const nodeModuleRoots = [
 		resolve(appRoot, "node_modules"),
 		resolve(appRoot, ".feynman", "npm", "node_modules"),
@@ -99,42 +143,49 @@ export function patchPiRuntimeNodeModules(appRoot: string, feynmanAgentDir?: str
 			"pi-coding-agent",
 			"package.json",
 			patchPiCodingAgentPackageJsonSource,
+			bundledPiVersion,
 		) || changed;
 		changed = patchScopedPiPackageFileIfPresent(
 			nodeModulesPath,
 			"pi-agent-core",
 			"dist/agent-loop.js",
 			patchPiAgentCoreSource,
+			bundledPiVersion,
 		) || changed;
 		changed = patchScopedPiPackageFileIfPresent(
 			nodeModulesPath,
 			"pi-tui",
 			"dist/tui.js",
 			patchPiTuiSource,
+			bundledPiVersion,
 		) || changed;
 		changed = patchScopedPiPackageFileIfPresent(
 			nodeModulesPath,
 			"pi-tui",
 			"dist/components/editor.js",
 			patchPiEditorSource,
+			bundledPiVersion,
 		) || changed;
 		changed = patchScopedPiPackageFileIfPresent(
 			nodeModulesPath,
 			"pi-coding-agent",
 			"dist/modes/interactive/theme/theme.js",
 			patchPiInteractiveThemeSource,
+			bundledPiVersion,
 		) || changed;
 		changed = patchScopedPiPackageFileIfPresent(
 			nodeModulesPath,
 			"pi-coding-agent",
 			"dist/core/model-registry.js",
 			patchPiModelRegistrySource,
+			bundledPiVersion,
 		) || changed;
 		changed = patchScopedPiPackageFileIfPresent(
 			nodeModulesPath,
 			"pi-coding-agent",
 			"dist/core/model-runtime.js",
 			patchPiModelRegistrySource,
+			bundledPiVersion,
 		) || changed;
 		changed = patchFileIfPresent(
 			resolve(nodeModulesPath, "@modelcontextprotocol", "sdk", "package.json"),

--- a/tests/pi-runtime-patches.test.ts
+++ b/tests/pi-runtime-patches.test.ts
@@ -265,7 +265,21 @@ test("patchPiRuntimeNodeModules patches installed Pi runtime files", async () =>
 	writeFileSync(themePath, THEME_SOURCE, "utf8");
 	writeFileSync(
 		packageJsonPath,
-		JSON.stringify({ name: "@earendil-works/pi-coding-agent", piConfig: { configDir: ".pi" } }, null, 2) + "\n",
+		JSON.stringify({
+			name: "@earendil-works/pi-coding-agent",
+			version: "0.82.1",
+			piConfig: { configDir: ".pi" },
+		}, null, 2) + "\n",
+		"utf8",
+	);
+	writeFileSync(
+		join(dirname(dirname(agentLoopPath)), "package.json"),
+		JSON.stringify({ name: "@earendil-works/pi-agent-core", version: "0.82.1" }, null, 2) + "\n",
+		"utf8",
+	);
+	writeFileSync(
+		join(dirname(dirname(tuiPath)), "package.json"),
+		JSON.stringify({ name: "@earendil-works/pi-tui", version: "0.82.1" }, null, 2) + "\n",
 		"utf8",
 	);
 	writeFileSync(modelRegistryPath, MODEL_REGISTRY_SOURCE, "utf8");
@@ -343,7 +357,21 @@ test("patchPiRuntimeNodeModules patches the vendored runtime workspace", async (
 	writeFileSync(themePath, THEME_SOURCE, "utf8");
 	writeFileSync(
 		packageJsonPath,
-		JSON.stringify({ name: "@mariozechner/pi-coding-agent", piConfig: { configDir: ".pi" } }, null, 2) + "\n",
+		JSON.stringify({
+			name: "@mariozechner/pi-coding-agent",
+			version: "0.82.1",
+			piConfig: { configDir: ".pi" },
+		}, null, 2) + "\n",
+		"utf8",
+	);
+	writeFileSync(
+		join(dirname(dirname(agentLoopPath)), "package.json"),
+		JSON.stringify({ name: "@mariozechner/pi-agent-core", version: "0.82.1" }, null, 2) + "\n",
+		"utf8",
+	);
+	writeFileSync(
+		join(dirname(dirname(tuiPath)), "package.json"),
+		JSON.stringify({ name: "@mariozechner/pi-tui", version: "0.82.1" }, null, 2) + "\n",
 		"utf8",
 	);
 	writeFileSync(webAccessPath, WEB_ACCESS_INDEX_SOURCE, "utf8");
@@ -375,10 +403,17 @@ test("patchPiRuntimeNodeModules patches the vendored runtime workspace", async (
 	assert.equal(patchPiRuntimeNodeModules(appRoot), false);
 });
 
-test("patchPiRuntimeNodeModules patches Feynman user and Pi agent package roots", async () => {
+test("patchPiRuntimeNodeModules leaves stale Pi core packages untouched while patching extensions", async () => {
 	const appRoot = mkdtempSync(join(tmpdir(), "feynman-user-runtime-patches-"));
 	const homeRoot = mkdtempSync(join(tmpdir(), "feynman-user-runtime-home-"));
 	const agentDir = join(homeRoot, ".feynman", "agent");
+	const bundledPiManifestPath = join(
+		appRoot,
+		"node_modules",
+		"@earendil-works",
+		"pi-coding-agent",
+		"package.json",
+	);
 	const globalSpawnPath = join(
 		homeRoot,
 		".feynman",
@@ -432,18 +467,80 @@ test("patchPiRuntimeNodeModules patches Feynman user and Pi agent package roots"
 		"extensions",
 		"indexer.ts",
 	);
+	const agentEditorPath = join(
+		agentDir,
+		"npm",
+		"node_modules",
+		"@earendil-works",
+		"pi-tui",
+		"dist",
+		"components",
+		"editor.js",
+	);
+	const agentTuiManifestPath = join(
+		agentDir,
+		"npm",
+		"node_modules",
+		"@earendil-works",
+		"pi-tui",
+		"package.json",
+	);
+	const agentCodingManifestPath = join(
+		agentDir,
+		"npm",
+		"node_modules",
+		"@earendil-works",
+		"pi-coding-agent",
+		"package.json",
+	);
+	const agentModelRegistryPath = join(
+		agentDir,
+		"npm",
+		"node_modules",
+		"@earendil-works",
+		"pi-coding-agent",
+		"dist",
+		"core",
+		"model-registry.js",
+	);
 	await mkdir(dirname(globalSpawnPath), { recursive: true });
 	await mkdir(dirname(agentSpawnPath), { recursive: true });
 	await mkdir(dirname(globalOtelConfigPath), { recursive: true });
 	await mkdir(dirname(agentOtelConfigPath), { recursive: true });
 	await mkdir(dirname(globalSessionSearchPath), { recursive: true });
 	await mkdir(dirname(agentSessionSearchPath), { recursive: true });
+	await mkdir(dirname(bundledPiManifestPath), { recursive: true });
+	await mkdir(dirname(agentEditorPath), { recursive: true });
+	await mkdir(dirname(agentModelRegistryPath), { recursive: true });
 	writeFileSync(globalSpawnPath, SUBAGENT_PI_SPAWN_SOURCE, "utf8");
 	writeFileSync(agentSpawnPath, SUBAGENT_PI_SPAWN_SOURCE, "utf8");
 	writeFileSync(globalOtelConfigPath, PI_OTEL_CONFIG_SOURCE, "utf8");
 	writeFileSync(agentOtelConfigPath, PI_OTEL_CONFIG_SOURCE, "utf8");
 	writeFileSync(globalSessionSearchPath, SESSION_SEARCH_INDEXER_SOURCE, "utf8");
 	writeFileSync(agentSessionSearchPath, SESSION_SEARCH_INDEXER_SOURCE, "utf8");
+	writeFileSync(
+		bundledPiManifestPath,
+		JSON.stringify({ name: "@earendil-works/pi-coding-agent", version: "0.82.1" }, null, 2) + "\n",
+		"utf8",
+	);
+	writeFileSync(
+		agentTuiManifestPath,
+		JSON.stringify({ name: "@earendil-works/pi-tui", version: "0.80.6" }, null, 2) + "\n",
+		"utf8",
+	);
+	writeFileSync(
+		agentCodingManifestPath,
+		JSON.stringify({
+			name: "@earendil-works/pi-coding-agent",
+			version: "0.80.6",
+			piConfig: { configDir: ".pi" },
+		}, null, 2) + "\n",
+		"utf8",
+	);
+	const staleEditorSource = "export class Editor { render() { return []; } }\n";
+	const staleModelRegistrySource = "export class ModelRegistry { getModel() { return undefined; } }\n";
+	writeFileSync(agentEditorPath, staleEditorSource, "utf8");
+	writeFileSync(agentModelRegistryPath, staleModelRegistrySource, "utf8");
 
 	assert.equal(patchPiRuntimeNodeModules(appRoot, agentDir), true);
 
@@ -463,6 +560,12 @@ test("patchPiRuntimeNodeModules patches Feynman user and Pi agent package roots"
 		assert.match(source, /process\.env\.FEYNMAN_SESSION_DIR/);
 		assert.match(source, /process\.env\.PI_SESSION_DIR/);
 	}
+	assert.equal(readFileSync(agentEditorPath, "utf8"), staleEditorSource);
+	assert.equal(readFileSync(agentModelRegistryPath, "utf8"), staleModelRegistrySource);
+	const staleCodingManifest = JSON.parse(readFileSync(agentCodingManifestPath, "utf8")) as {
+		piConfig?: { configDir?: string };
+	};
+	assert.equal(staleCodingManifest.piConfig?.configDir, ".pi");
 	assert.equal(patchPiRuntimeNodeModules(appRoot, agentDir), false);
 });
 

--- a/tests/release-workflows.test.ts
+++ b/tests/release-workflows.test.ts
@@ -45,6 +45,12 @@ test("PR and publish workflows require clean package and consumer audits", () =>
 	}
 });
 
+test("package and native release gates exercise persisted Pi user-package upgrades", () => {
+	const staleUpgradeVerifier = /node scripts\/verify-stale-pi-upgrade\.mjs/g;
+	assert.equal((e2eWorkflow.match(staleUpgradeVerifier) ?? []).length, 1);
+	assert.equal((publishWorkflow.match(staleUpgradeVerifier) ?? []).length, 3);
+});
+
 test("package gates exercise the global npm install path", () => {
 	assert.ok(
 		packageManifest.bundleDependencies?.includes("@opentelemetry/api"),

--- a/website/src/content/docs/reference/releases.md
+++ b/website/src/content/docs/reference/releases.md
@@ -9,6 +9,16 @@ This page summarizes what changed in recent Feynman releases. GitHub releases us
 
 ## Unreleased
 
+## v0.3.8 - 2026-07-28
+
+### Reliability
+
+- Fixed standalone upgrades failing at launch with `Unsupported Pi editor layout` when an older Pi core dependency remained in the user's package directory. Startup now leaves stale Pi core copies untouched while continuing to patch installed extensions, which Pi loads against Feynman's current bundled runtime.
+
+### Validation
+
+- Added an installed-package and native-bundle upgrade smoke that stages a Pi `0.80.6` user-package tree, proves its core files remain unchanged, verifies extension patching stays idempotent, and launches Feynman through RPC twice before a release can publish.
+
 ## v0.3.7 - 2026-07-28
 
 ### Reliability


### PR DESCRIPTION
## Summary

- skip Feynman's Pi core patchers for user-package copies whose explicit version differs from the bundled Pi runtime
- keep security, MCP, and extension patching active in the same user roots
- gate npm and native releases on two RPC launches with a staged Pi 0.80.6 tree
- release as 0.3.8

## Root cause

Pi persists package dependencies under `<agentDir>/npm`. A standalone upgrade could therefore retain Pi 0.80.6 core packages while Feynman 0.3.7 bundled Pi 0.82.1. Startup patched every discovered core copy as if it matched the bundled runtime. The stale editor failed the current editor anchor, and extending that one anchor exposed an incompatible stale ModelRegistry next. Pi 0.82.1 already aliases extension peer imports to its bundled core, so historical core trees should not be patched.

## Verification

- focused tests: 26/26
- full tests: 655/655
- typecheck, build, architecture check, actionlint, diff check
- website lint/typecheck/build: 34 pages
- root, website, runtime, installed-consumer audits: 0 vulnerabilities
- fresh official Pi 0.80.6 tree: core hashes unchanged; patch passes `true` then `false`; two RPC launches passed
- dry/real pack: 111,634,612 bytes, 39,692 entries, SHA-256 `daaf0e114b4e708269629edc99b166f782990f0940105265f6efa2dade0c1376`
- clean installed tarball: artifact verification and two-pass stale-upgrade smoke passed
- macOS arm64 native bundle: two-pass stale-upgrade smoke passed, SHA-256 `6db6e81d58b91a0b78d043e9532b078341aaae0bf965dfa8c65d158690c1660f`

Closes #202
