### PR TITLE
Release 0.3.11 with pi-subagents 0.40.0

### DIFF
--- a/.feynman/runtime-package-lock.json
+++ b/.feynman/runtime-package-lock.json
@@ -15,7 +15,7 @@
         "pi-btw": "0.4.1",
         "pi-docparser": "3.0.1",
         "pi-otel": "0.1.0",
-        "pi-subagents": "0.38.0",
+        "pi-subagents": "0.40.0",
         "pi-web-access": "0.17.1",
         "typebox": "1.3.7",
         "undici": "8.9.0"
@@ -5203,9 +5203,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.6",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.6.tgz",
-      "integrity": "sha512-HwMtbJjMw8rC8dUTwCNilHJD+fxTeKM3JV1eprSmTjS41qwXSSt6exJXgyPK1QOu0jB9eDYLESRDkB3qaT3jnw==",
+      "version": "6.2.7",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.7.tgz",
+      "integrity": "sha512-hq1OB1bALKfydZNoViyg6hPVGV4i93ny9Op+n4zP5RSf7SCZEXa/TsG2O3IEr7+WlHRTPnpqDmHfMH6qXAD60w==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -5655,9 +5655,9 @@
       }
     },
     "node_modules/pi-subagents": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/pi-subagents/-/pi-subagents-0.38.0.tgz",
-      "integrity": "sha512-8wGQiX6rkR5J4V+AnWtQg3+LmC+cHnZIM1f/VWTjCTkVmcoKdeLsTAYG6BS2yKAugyEUjNUGj3vE5d9nj9m61A==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/pi-subagents/-/pi-subagents-0.40.0.tgz",
+      "integrity": "sha512-DdFXqmRMLhCcGs32zN14hm4AztDuhG0b8yka8pzO+5GsYseifJnT/hfcqr/skPhtoDqA1qcQbucj1dciC0OQzg==",
       "license": "MIT",
       "dependencies": {
         "jiti": "2.7.0",

--- a/.feynman/settings.json
+++ b/.feynman/settings.json
@@ -2,7 +2,7 @@
   "themes": ["-themes/feynman.json"],
   "packages": [
     "npm:@companion-ai/alpha-hub@0.1.3",
-    "npm:pi-subagents@0.38.0",
+    "npm:pi-subagents@0.40.0",
     "npm:pi-btw@0.4.1",
     "npm:pi-docparser@3.0.1",
     "npm:pi-web-access@0.17.1",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Workspace lab notebook for long-running or resumable research work.
 
 Use this file to track chronology, not release notes. Keep entries short, factual, and operational.
 
+### 2026-08-01 22:00 PDT — intake-sweep-pi-subagents-0.40
+
+- Objective: Process the only post-`0.3.10` in-scope intake change, preserve the clean unrelated Lima worktree, and carry `pi-subagents@0.40.0` through a `0.3.11` release.
+- Changed: Updated the bundled/default/runtime-locked subagent package to `0.40.0`; retained automatic migration for both the `0.3.10` (`pi-subagents@0.38.0`) and `0.3.6` (`0.37.2`) default package sets; bumped Feynman to `0.3.11`; and added matching repository/website release notes. TypeBox remains at Pi `0.83.0`'s exact `1.3.7` contract.
+- Source proof: npm `pi-subagents@0.40.0` resolves to upstream tag commit `d4d2ab706b612ccd173caad2bc202eef07e7eda3`; upstream CI `30721272104` passed Ubuntu and Windows. The installed package exposes the reviewed capability ceilings, usage budgets, approval checkpoints, runtime-extension acknowledgement, signal status, process/output separation, and model/thinking visibility paths.
+- Verified locally: Focused package/settings/runtime/release coverage passed `92/92`; full tests passed `728/728`; typecheck, build, architecture check, website lint/typecheck/build (`34` pages), root/site/runtime/consumer audits, package freshness review, `git diff --check`, package-artifact verification, stale-Pi upgrade, and clean local/global installed-runtime RPC/TypeBox checks passed. Registry signature audit reported zero invalid or missing packages, and real authenticated `openai/gpt-5.5` parent plus `researcher` subagent smokes returned `PARENT_OK` and `RESULT=PONG`.
+- Package proof: Dry and real packs matched at `112,546,426` bytes, `329,608,636` unpacked bytes, and `39,705` files. The tarball SHA-256 is `79f8a976fc9dc4a4e2d4ffd1616b42798a6fd18ad0716241e35ab6933a108612`; the embedded runtime SHA-256 is `cad4ab09354c89cc5026ecbf78573ff6e0a4b08ae95b72a5205a6b3be7471ab3`.
+- State: `verified` locally and `unverified` for exact-commit Daytona, PR CI, merge, and npm/GitHub/native publication. Next: commit and push the candidate, prove that exact commit in a disposable Daytona sandbox and required CI, then merge and verify every `0.3.11` release surface.
+
 ### 2026-08-01 10:00 PDT — intake-sweep-0.3.10-release-completion
 
 - Objective: Finish the Pi `0.83.0` migration, Windows installer, package-update, and blocked-telemetry queue through exact-head proof, merge, publication, issue reconciliation, and cleanup.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,14 @@ GitHub release notes are generated from the matching `## vX.Y.Z` section in this
 
 ## Unreleased
 
+## v0.3.11 - 2026-08-01
+
+### Research agents
+
+- Updated `pi-subagents` to `0.40.0` so delegated research runs have stable child identities, explicit signal-termination status, separate process and output-availability state, and clearer model and thinking-level visibility.
+- Added session-scoped agent capability ceilings, chain approval checkpoints, reported token and cost budgets, and child-runtime extension acknowledgements for safer, more auditable multi-agent research workflows.
+- Restored automatic package reconciliation for workspaces that retained either the `0.3.10` or older `0.3.6` bundled package defaults.
+
 ## v0.3.10 - 2026-08-01
 
 ### Runtime

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@companion-ai/feynman",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "bundleDependencies": [
         "@companion-ai/alpha-hub",
         "@earendil-works/pi-agent-core",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Research-first CLI agent built on Pi and alphaXiv",
   "license": "MIT",
   "type": "module",

--- a/src/pi/package-presets.ts
+++ b/src/pi/package-presets.ts
@@ -9,7 +9,7 @@ const UNPINNED_CORE_PACKAGE_SOURCES = [
 	"npm:pi-otel",
 ] as const;
 
-const PREVIOUS_CORE_PACKAGE_SOURCES = [
+const LEGACY_PREVIOUS_CORE_PACKAGE_SOURCES = [
 	"npm:@companion-ai/alpha-hub@0.1.3",
 	"npm:pi-subagents@0.37.2",
 	"npm:pi-btw@0.4.1",
@@ -18,9 +18,18 @@ const PREVIOUS_CORE_PACKAGE_SOURCES = [
 	"npm:pi-otel@0.1.0",
 ] as const;
 
-export const CORE_PACKAGE_SOURCES = [
+const PREVIOUS_CORE_PACKAGE_SOURCES = [
 	"npm:@companion-ai/alpha-hub@0.1.3",
 	"npm:pi-subagents@0.38.0",
+	"npm:pi-btw@0.4.1",
+	"npm:pi-docparser@3.0.1",
+	"npm:pi-web-access@0.17.1",
+	"npm:pi-otel@0.1.0",
+] as const;
+
+export const CORE_PACKAGE_SOURCES = [
+	"npm:@companion-ai/alpha-hub@0.1.3",
+	"npm:pi-subagents@0.40.0",
 	"npm:pi-btw@0.4.1",
 	"npm:pi-docparser@3.0.1",
 	"npm:pi-web-access@0.17.1",
@@ -67,6 +76,11 @@ const LEGACY_ADJACENT_PACKAGE_SOURCES = [
 ] as const;
 
 const LEGACY_PINNED_CORE_PACKAGE_SOURCES = [
+	...LEGACY_PREVIOUS_CORE_PACKAGE_SOURCES,
+	...LEGACY_ADJACENT_PACKAGE_SOURCES,
+] as const;
+
+const PREVIOUS_PINNED_CORE_PACKAGE_SOURCES = [
 	...PREVIOUS_CORE_PACKAGE_SOURCES,
 	...LEGACY_ADJACENT_PACKAGE_SOURCES,
 ] as const;
@@ -177,7 +191,26 @@ const LEGACY_DEFAULT_PACKAGE_SETS = [
 		...LEGACY_PINNED_CORE_PACKAGE_SOURCES,
 	],
 	[
+		...PREVIOUS_PINNED_CORE_PACKAGE_SOURCES,
+	],
+	[
 		...LEGACY_CURRENT_PINNED_CORE_PACKAGE_SOURCES,
+	],
+	[
+		...LEGACY_PREVIOUS_CORE_PACKAGE_SOURCES,
+	],
+	[
+		...LEGACY_PREVIOUS_CORE_PACKAGE_SOURCES,
+		"npm:pi-generative-ui",
+	],
+	[
+		...LEGACY_PREVIOUS_CORE_PACKAGE_SOURCES,
+		"npm:@devkade/pi-opentelemetry",
+	],
+	[
+		...LEGACY_PREVIOUS_CORE_PACKAGE_SOURCES,
+		"npm:@devkade/pi-opentelemetry",
+		"npm:pi-generative-ui",
 	],
 	[
 		...PREVIOUS_CORE_PACKAGE_SOURCES,

--- a/tests/pi-settings.test.ts
+++ b/tests/pi-settings.test.ts
@@ -98,7 +98,7 @@ test("bundled settings and package-list defaults use the same current core packa
 	assert.deepEqual(bundledSettings.packages, [...CORE_PACKAGE_SOURCES]);
 	assert.deepEqual(CORE_PACKAGE_SOURCES, [
 		"npm:@companion-ai/alpha-hub@0.1.3",
-		"npm:pi-subagents@0.38.0",
+		"npm:pi-subagents@0.40.0",
 		"npm:pi-btw@0.4.1",
 		"npm:pi-docparser@3.0.1",
 		"npm:pi-web-access@0.17.1",
@@ -106,7 +106,7 @@ test("bundled settings and package-list defaults use the same current core packa
 	]);
 });
 
-test("normalizeFeynmanSettings upgrades the previous pinned core package set", async () => {
+test("normalizeFeynmanSettings upgrades the 0.3.6 pinned core package set", async () => {
 	const root = mkdtempSync(join(tmpdir(), "feynman-settings-"));
 	const settingsPath = join(root, "settings.json");
 	const bundledSettingsPath = join(root, "bundled-settings.json");
@@ -121,6 +121,35 @@ test("normalizeFeynmanSettings upgrades the previous pinned core package set", a
 				"npm:pi-btw@0.4.1",
 				"npm:pi-docparser@3.0.1",
 				"npm:pi-web-access@0.15.0",
+				"npm:pi-otel@0.1.0",
+			],
+		}, null, 2) + "\n",
+		"utf8",
+	);
+	writeFileSync(bundledSettingsPath, "{}\n", "utf8");
+	writeFileSync(authPath, "{}\n", "utf8");
+
+	await normalizeFeynmanSettings(settingsPath, bundledSettingsPath, "medium", authPath);
+
+	const settings = JSON.parse(readFileSync(settingsPath, "utf8")) as { packages?: string[] };
+	assert.deepEqual(settings.packages, [...CORE_PACKAGE_SOURCES]);
+});
+
+test("normalizeFeynmanSettings upgrades the 0.3.10 pinned core package set", async () => {
+	const root = mkdtempSync(join(tmpdir(), "feynman-settings-"));
+	const settingsPath = join(root, "settings.json");
+	const bundledSettingsPath = join(root, "bundled-settings.json");
+	const authPath = join(root, "auth.json");
+
+	writeFileSync(
+		settingsPath,
+		JSON.stringify({
+			packages: [
+				"npm:@companion-ai/alpha-hub@0.1.3",
+				"npm:pi-subagents@0.38.0",
+				"npm:pi-btw@0.4.1",
+				"npm:pi-docparser@3.0.1",
+				"npm:pi-web-access@0.17.1",
 				"npm:pi-otel@0.1.0",
 			],
 		}, null, 2) + "\n",
@@ -278,9 +307,9 @@ test("optional package presets map friendly aliases", () => {
 });
 
 test("package update sources map core and optional aliases", () => {
-	assert.deepEqual(resolvePackageUpdateSources("pi-subagents"), ["npm:pi-subagents@0.38.0"]);
-	assert.deepEqual(resolvePackageUpdateSources("subagents"), ["npm:pi-subagents@0.38.0"]);
-	assert.deepEqual(resolvePackageUpdateSources("npm:pi-subagents"), ["npm:pi-subagents@0.38.0"]);
+	assert.deepEqual(resolvePackageUpdateSources("pi-subagents"), ["npm:pi-subagents@0.40.0"]);
+	assert.deepEqual(resolvePackageUpdateSources("subagents"), ["npm:pi-subagents@0.40.0"]);
+	assert.deepEqual(resolvePackageUpdateSources("npm:pi-subagents"), ["npm:pi-subagents@0.40.0"]);
 	assert.deepEqual(resolvePackageUpdateSources("pi-web-access"), ["npm:pi-web-access@0.17.1"]);
 	assert.deepEqual(resolvePackageUpdateSources("alpha-hub"), ["npm:@companion-ai/alpha-hub@0.1.3"]);
 	assert.deepEqual(resolvePackageUpdateSources("npm:pi-subagents@0.37.2"), ["npm:pi-subagents@0.37.2"]);

--- a/website/src/content/docs/reference/releases.md
+++ b/website/src/content/docs/reference/releases.md
@@ -9,6 +9,14 @@ This page summarizes what changed in recent Feynman releases. GitHub releases us
 
 ## Unreleased
 
+## v0.3.11 - 2026-08-01
+
+### Research agents
+
+- Updated `pi-subagents` to `0.40.0` so delegated research runs have stable child identities, explicit signal-termination status, separate process and output-availability state, and clearer model and thinking-level visibility.
+- Added session-scoped agent capability ceilings, chain approval checkpoints, reported token and cost budgets, and child-runtime extension acknowledgements for safer, more auditable multi-agent research workflows.
+- Restored automatic package reconciliation for workspaces that retained either the `0.3.10` or older `0.3.6` bundled package defaults.
+
 ## v0.3.10 - 2026-08-01
 
 ### Runtime


### PR DESCRIPTION
## Summary

- update bundled/runtime-locked `pi-subagents` from 0.38.0 to 0.40.0
- preserve automatic migration for both the 0.3.10 and 0.3.6 managed package presets
- release Feynman 0.3.11 with matching package, release-note, website, and lab-notebook metadata
- refresh the runtime lock, including `jose` 6.2.7, while preserving Pi 0.83.0's TypeBox 1.3.7 contract

## Upstream evidence

- `pi-subagents@0.40.0` npm git head: `d4d2ab706b612ccd173caad2bc202eef07e7eda3`
- upstream workflow `30721272104`: Ubuntu and Windows passed

## Verification

Exact candidate: `03fdb2a4c816e2de5c128821c0e48bf0011b2f73`

- focused tests: 92/92
- full tests: 728/728
- `npm run typecheck`
- `npm run build`
- `npm run architecture:check`
- website lint/typecheck/build: 34 pages
- root, website, runtime, and installed-consumer production audits
- `npm outdated` reviewed
- `git diff --check`
- dry and real npm pack shapes matched and stayed within package budget
- real tarball clean local/global consumer installs
- package artifact and installed-runtime RPC/TypeBox verification
- stale Pi 0.80.6 two-launch migration smoke
- authenticated OpenAI parent smoke: `PARENT_OK`
- authenticated `researcher` subagent smoke: `RESULT=PONG`
- registry signature audit: zero invalid or missing packages

Clean-machine Daytona receipt:

- sandbox: `7e3db21f-b329-4331-b4e2-4ce07e156dc4` (`daytona-medium`, Debian 13, Node 24.18.0)
- checked out exact candidate `03fdb2a4c816e2de5c128821c0e48bf0011b2f73`
- source, website, pack, clean local/global consumers, audits, stale-Pi, package-artifact, and installed-runtime checks passed
- packed tarball: 113,095,746 bytes; 330,108,064 unpacked; 39,702 files
- dry/real integrity matched: `sha512-L/cWUqE1MitHhTntq57wcZdZEjQT2x2NZytMjXFn+JxeeVE5wmnearF5+/kMKiHq/tSArrqpBTMaFM/mUJ62bA==`
- tarball SHA-256: `12d36457caa982e8d4cdde292c4aef70a935a7d06aeabad52a1108c51859fada`
- sandbox deleted and confirmed absent
