### PR TITLE
Verify live published native installers

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -185,6 +185,95 @@ jobs:
           grep -o "RESULT=PONG" subagent.log | head -1
           echo "subagent smoke ok"
 
+  published-native-installer-e2e:
+    if: github.event_name == 'workflow_dispatch'
+    name: native installer (${{ matrix.os }})
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-14
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "24.18.0"
+
+      - name: Install the published native bundle through the live Unix installer
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          expected=$(npm view "@companion-ai/feynman@${FEYNMAN_VERSION_INPUT}" version | tail -1)
+          install_root="$RUNNER_TEMP/feynman-native-install"
+          installer="$RUNNER_TEMP/feynman-install.sh"
+          curl --fail --location --silent --show-error \
+            https://feynman.is/install \
+            --output "$installer"
+          FEYNMAN_INSTALL_BIN_DIR="$install_root/bin" \
+            FEYNMAN_INSTALL_APP_DIR="$install_root/app" \
+            FEYNMAN_INSTALL_SKIP_PATH_UPDATE=1 \
+            sh "$installer" "$FEYNMAN_VERSION_INPUT"
+
+          bin="$install_root/bin/feynman"
+          test "$("$bin" --version | tail -1)" = "$expected"
+          "$bin" --help >/dev/null
+          case "$(uname -s)" in
+            Darwin) os=darwin ;;
+            Linux) os=linux ;;
+            *) exit 1 ;;
+          esac
+          case "$(uname -m)" in
+            x86_64 | amd64) arch=x64 ;;
+            arm64 | aarch64) arch=arm64 ;;
+            *) exit 1 ;;
+          esac
+          bundle="$install_root/app/feynman-$expected-$os-$arch"
+          test -x "$bundle/feynman"
+          "$bundle/node/bin/node" \
+            "$bundle/app/scripts/verify-installed-runtime.mjs" \
+            "$bin"
+
+      - name: Install the published native bundle through the live Windows installer
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $expected = (
+            & npm view "@companion-ai/feynman@$env:FEYNMAN_VERSION_INPUT" version |
+              Select-Object -Last 1
+          ).ToString().Trim()
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not resolve the requested npm version."
+          }
+
+          $env:LOCALAPPDATA = Join-Path $env:RUNNER_TEMP "FeynmanLocalAppData"
+          $env:FEYNMAN_HOME = Join-Path $env:RUNNER_TEMP "FeynmanHome"
+          New-Item -ItemType Directory -Path $env:LOCALAPPDATA -Force | Out-Null
+          & ([scriptblock]::Create((irm https://feynman.is/install.ps1))) `
+            -Version $env:FEYNMAN_VERSION_INPUT
+
+          $installRoot = Join-Path $env:LOCALAPPDATA "Programs\feynman"
+          $bin = Join-Path $installRoot "bin\feynman.cmd"
+          $installed = (& $bin --version | Select-Object -Last 1).ToString().Trim()
+          if ($LASTEXITCODE -ne 0 -or $installed -ne $expected) {
+            throw "Installed version mismatch: expected=$expected actual=$installed"
+          }
+          & $bin --help | Out-Null
+          if ($LASTEXITCODE -ne 0) {
+            throw "Installed Windows launcher failed --help."
+          }
+          $bundle = Join-Path $installRoot "feynman-$expected-win32-x64"
+          & (Join-Path $bundle "node\node.exe") `
+            (Join-Path $bundle "app\scripts\verify-installed-runtime.mjs") `
+            $bin
+          if ($LASTEXITCODE -ne 0) {
+            throw "Installed Windows runtime verification failed."
+          }
+
   release-candidate-pr:
     if: github.event_name == 'pull_request'
     name: Release candidate (PR)

--- a/tests/release-workflows.test.ts
+++ b/tests/release-workflows.test.ts
@@ -28,6 +28,22 @@ test("pull-request release gates validate the merge candidate", () => {
 	);
 });
 
+test("manual post-release gates exercise the live native installers", () => {
+	const installerJob = e2eWorkflow.match(
+		/\n  published-native-installer-e2e:[\s\S]*?(?=\n  release-candidate-pr:)/,
+	);
+	assert.ok(installerJob, "manual workflow must define the published native installer job");
+	assert.match(installerJob[0], /if: github\.event_name == 'workflow_dispatch'/);
+	assert.match(installerJob[0], /https:\/\/feynman\.is\/install\b/);
+	assert.match(installerJob[0], /https:\/\/feynman\.is\/install\.ps1/);
+	assert.match(installerJob[0], /FEYNMAN_INSTALL_BIN_DIR/);
+	assert.match(installerJob[0], /shell: powershell/);
+	assert.match(installerJob[0], /verify-installed-runtime\.mjs/);
+	for (const os of ["ubuntu-latest", "macos-14", "windows-latest"]) {
+		assert.match(installerJob[0], new RegExp(`- ${os}`));
+	}
+});
+
 test("PR and publish workflows require clean package and consumer audits", () => {
 	for (const workflow of [e2eWorkflow, publishWorkflow]) {
 		assert.match(workflow, /npm audit --omit=dev --prefix \.feynman\/npm/);
@@ -53,7 +69,7 @@ test("package and native release gates exercise persisted Pi user-package upgrad
 
 test("installed package gates verify Feynman commands, tools, and TypeBox schemas across launchers", () => {
 	const installedRuntimeVerifier = /scripts\/verify-installed-runtime\.mjs/g;
-	assert.equal((e2eWorkflow.match(installedRuntimeVerifier) ?? []).length, 4);
+	assert.equal((e2eWorkflow.match(installedRuntimeVerifier) ?? []).length, 5);
 	assert.equal((publishWorkflow.match(installedRuntimeVerifier) ?? []).length, 8);
 	for (const workflow of [e2eWorkflow, publishWorkflow]) {
 		assert.match(workflow, /bin="\$consumer\/node_modules\/\.bin\/feynman\.cmd"/);


### PR DESCRIPTION
## Summary

- add a manual post-release matrix for the public `feynman.is` Unix and Windows one-line installers on Ubuntu, macOS, and Windows
- verify the requested npm version, installed launcher, help path, and bundled runtime after each live native installation
- keep the existing source/package PR candidate gates unchanged

## Why

The release workflow already builds and verifies all five native archives, while the PR workflow validates the Windows installer against a local candidate. This closes the remaining release-proof gap: the deployed installer scripts, public GitHub release assets, checksums, platform extraction, installed launcher, and runtime now have one durable end-to-end gate after publication.

## Verification

Exact commit: `f85da4bce0b99a34c496d6c4ddc2974fd595412c`

- focused release-workflow tests: 10/10
- full `npm test`: 729/729
- `npm run typecheck`
- `npm run build`
- `npm run architecture:check`
- website lint, typecheck, and build: 34 pages
- root, website, and bundled runtime production audits: zero vulnerabilities
- `actionlint .github/workflows/*.yml`
- `git diff --check`
- dry and real pack: 112,546,426 bytes, 329,608,636 unpacked bytes, 39,705 files, SHA-256 `79f8a976fc9dc4a4e2d4ffd1616b42798a6fd18ad0716241e35ab6933a108612`
