### PR TITLE
fix: patch alpha ask for current paper/queries MCP schema

### DIFF
--- a/scripts/lib/alpha-hub-ask-patch.d.mts
+++ b/scripts/lib/alpha-hub-ask-patch.d.mts
@@ -1,0 +1,1 @@
+export declare function patchAlphaHubAskSource(source: string): string;

--- a/scripts/lib/alpha-hub-ask-patch.mjs
+++ b/scripts/lib/alpha-hub-ask-patch.mjs
@@ -1,0 +1,16 @@
+// Issue #214: alphaXiv's answer_pdf_queries tool now requires
+// { paper: string, queries: string[] }. Bundled alpha-hub@0.1.3 still sends
+// { urls, queries }, so MCP rejects the call with -32602.
+
+const LEGACY_ASK_ARGS = "callTool('answer_pdf_queries', { urls: [url], queries: [query] })";
+const CURRENT_ASK_ARGS = "callTool('answer_pdf_queries', { paper: url, queries: [query] })";
+
+export function patchAlphaHubAskSource(source) {
+	let patched = source;
+
+	if (patched.includes(LEGACY_ASK_ARGS)) {
+		patched = patched.replace(LEGACY_ASK_ARGS, CURRENT_ASK_ARGS);
+	}
+
+	return patched;
+}

--- a/scripts/lib/runtime-workspace-integrity.mjs
+++ b/scripts/lib/runtime-workspace-integrity.mjs
@@ -29,6 +29,7 @@ export const RUNTIME_INPUT_FILES = Object.freeze([
 	"scripts/lib/pi-shrinkwrap-security-patch.mjs",
 	"scripts/lib/pi-undici-proxy-patch.mjs",
 	"scripts/lib/alpha-hub-auth-patch.mjs",
+	"scripts/lib/alpha-hub-ask-patch.mjs",
 	"scripts/lib/alpha-hub-search-patch.mjs",
 	"scripts/lib/mcp-sdk-package-patch.mjs",
 	"scripts/lib/deterministic-archive.mjs",

--- a/scripts/patch-embedded-pi.mjs
+++ b/scripts/patch-embedded-pi.mjs
@@ -5,6 +5,7 @@ import { homedir } from "node:os";
 import { delimiter, dirname, isAbsolute, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { FEYNMAN_LOGO_HTML } from "../logo.mjs";
+import { patchAlphaHubAskSource } from "./lib/alpha-hub-ask-patch.mjs";
 import { patchAlphaHubAuthSource } from "./lib/alpha-hub-auth-patch.mjs";
 import { patchAlphaHubSearchResultsSource, patchAlphaHubSearchSource } from "./lib/alpha-hub-search-patch.mjs";
 import { patchMcpSdkPackageJsonSource } from "./lib/mcp-sdk-package-patch.mjs";
@@ -1070,7 +1071,7 @@ if (alphaHubAuthPath && existsSync(alphaHubAuthPath)) {
 }
 if (alphaHubSearchPath && existsSync(alphaHubSearchPath)) {
 	const source = readFileSync(alphaHubSearchPath, "utf8");
-	const patched = patchAlphaHubSearchSource(source);
+	const patched = patchAlphaHubAskSource(patchAlphaHubSearchSource(source));
 	if (patched !== source) {
 		writeFileSync(alphaHubSearchPath, patched, "utf8");
 	}
@@ -1088,7 +1089,7 @@ if (alphaHubIndexPath && existsSync(alphaHubIndexPath)) {
 const workspaceAlphaHubLib = resolve(workspaceRoot, "@companion-ai", "alpha-hub", "src", "lib");
 for (const [fileName, patchFn] of [
 	["auth.js", patchAlphaHubAuthSource],
-	["alphaxiv.js", patchAlphaHubSearchSource],
+	["alphaxiv.js", (source) => patchAlphaHubAskSource(patchAlphaHubSearchSource(source))],
 	["index.js", patchAlphaHubSearchResultsSource],
 ]) {
 	const filePath = resolve(workspaceAlphaHubLib, fileName);

--- a/scripts/prepare-runtime-workspace.mjs
+++ b/scripts/prepare-runtime-workspace.mjs
@@ -25,6 +25,7 @@ import { PI_WEB_ACCESS_PATCH_TARGETS, patchPiWebAccessSource } from "./lib/pi-we
 import { PI_SUBAGENTS_PATCH_TARGETS, patchPiSubagentsSource, stripPiSubagentBuiltinModelSource } from "./lib/pi-subagents-patch.mjs";
 import { PI_OTEL_PATCH_TARGETS, patchPiOtelSource } from "./lib/pi-otel-patch.mjs";
 import { PI_SESSION_SEARCH_PATCH_TARGETS, patchPiSessionSearchSource } from "./lib/pi-session-search-patch.mjs";
+import { patchAlphaHubAskSource } from "./lib/alpha-hub-ask-patch.mjs";
 import { patchAlphaHubAuthSource } from "./lib/alpha-hub-auth-patch.mjs";
 import { patchAlphaHubSearchSource } from "./lib/alpha-hub-search-patch.mjs";
 import { patchMcpSdkPackageJsonSource } from "./lib/mcp-sdk-package-patch.mjs";
@@ -671,7 +672,7 @@ function patchBundledAlphaHub() {
 	}
 	if (existsSync(alphaxivPath)) {
 		const source = readFileSync(alphaxivPath, "utf8");
-		const patched = patchAlphaHubSearchSource(source);
+		const patched = patchAlphaHubAskSource(patchAlphaHubSearchSource(source));
 		if (patched !== source) {
 			writeFileSync(alphaxivPath, patched, "utf8");
 			changed = true;

--- a/scripts/verify-package-artifact.mjs
+++ b/scripts/verify-package-artifact.mjs
@@ -369,7 +369,11 @@ requireMarkers(
 requireMarkers(
 	readText(resolve(alphaLib, "alphaxiv.js"), "bundled alpha-hub search"),
 	"bundled alpha-hub search",
-	["async function searchRestFast(", "return await fallbackSearch("],
+	[
+		"async function searchRestFast(",
+		"return await fallbackSearch(",
+		"callTool('answer_pdf_queries', { paper: url, queries: [query] })",
+	],
 );
 requireMarkers(
 	readText(resolve(alphaLib, "index.js"), "bundled alpha-hub parser"),

--- a/src/pi/runtime-patches.ts
+++ b/src/pi/runtime-patches.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
+import { patchAlphaHubAskSource } from "../../scripts/lib/alpha-hub-ask-patch.mjs";
 import { patchAlphaHubAuthSource } from "../../scripts/lib/alpha-hub-auth-patch.mjs";
 import { patchAlphaHubSearchResultsSource, patchAlphaHubSearchSource } from "../../scripts/lib/alpha-hub-search-patch.mjs";
 import { patchMcpSdkPackageJsonSource } from "../../scripts/lib/mcp-sdk-package-patch.mjs";
@@ -316,7 +317,7 @@ export function patchPiRuntimeNodeModules(appRoot: string, feynmanAgentDir?: str
 		) || changed;
 		changed = patchFileIfPresent(
 			resolve(nodeModulesPath, "@companion-ai", "alpha-hub", "src", "lib", "alphaxiv.js"),
-			patchAlphaHubSearchSource,
+			(source) => patchAlphaHubAskSource(patchAlphaHubSearchSource(source)),
 		) || changed;
 		changed = patchFileIfPresent(
 			resolve(nodeModulesPath, "@companion-ai", "alpha-hub", "src", "lib", "index.js"),

--- a/tests/alpha-hub-ask-patch.test.ts
+++ b/tests/alpha-hub-ask-patch.test.ts
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { patchAlphaHubAskSource } from "../scripts/lib/alpha-hub-ask-patch.mjs";
+
+const LEGACY_SOURCE = [
+	"export async function answerPdfQuery(url, query) {",
+	"  try {",
+	"    return await callTool('answer_pdf_queries', { urls: [url], queries: [query] });",
+	"  } catch (err) {",
+	"    const message = err instanceof Error ? err.message : String(err);",
+	"    if (message.includes('Input validation error') || message.includes('Invalid arguments')) {",
+	"      return await callTool('answer_pdf_queries', { url, query });",
+	"    }",
+	"    throw err;",
+	"  }",
+	"}",
+].join("\n");
+
+test("patchAlphaHubAskSource sends paper and queries to answer_pdf_queries", () => {
+	const patched = patchAlphaHubAskSource(LEGACY_SOURCE);
+
+	assert.match(patched, /callTool\('answer_pdf_queries', \{ paper: url, queries: \[query\] \}\)/);
+	assert.doesNotMatch(patched, /callTool\('answer_pdf_queries', \{ urls: \[url\], queries: \[query\] \}\)/);
+	assert.match(patched, /callTool\('answer_pdf_queries', \{ url, query \}\)/);
+});
+
+test("patchAlphaHubAskSource is idempotent", () => {
+	const once = patchAlphaHubAskSource(LEGACY_SOURCE);
+	const twice = patchAlphaHubAskSource(once);
+	assert.equal(twice, once);
+});


### PR DESCRIPTION
- Fixes #214: feynman alpha ask failed because alpha-hub sent outdated MCP args (urls/query) instead of { paper, queries }.
- Adds a small launch/pack patch (same style as the alphaXiv login fix) so bundled alpha-hub uses the current schema.