### PR TITLE
fix: keep newer secure brace-expansion versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Workspace lab notebook for long-running or resumable research work.
 
 Use this file to track chronology, not release notes. Keep entries short, factual, and operational.
 
+### 2026-08-09 05:15 EDT — intake-sweep-brace-forward-compat-0.3.13
+
+- Objective: Resolve issue `#217` without weakening Pi's launch-time dependency repair, then release the exact verified candidate.
+- Intake: Issue `#217` is the only open issue and no PR is open. Two forks changed after the automation cutoff; both still match upstream `main`. The other `1,014` inspected forks add no current port target. The preserved Lima worktree is `92` commits behind `main` with no unique commit. The unrelated nested website repository remains dirty and unchanged outside the tracked release page.
+- Root cause: The security patch accepted only exact reviewed `brace-expansion` versions. Pi's agent-managed `<agentDir>/npm` tree can resolve a later secure release, so the next registry update would stop Feynman before CLI startup. Advisory `GHSA-rgw5-rvv9-x895` confirms `5.0.9` as the patched 5.x floor.
+- Changed: Valid semantic versions at or above `5.0.9` now remain intact in Pi shrinkwraps, owning locks, and installed trees. Reviewed vulnerable `5.0.6` through `5.0.8` trees still upgrade to exact `5.0.9`; malformed and older unsupported versions still fail closed. Added source, package-lock, installed-tree, and exact agent-managed runtime regressions. Bumped the candidate and public release notes to `0.3.13`.
+- Verified locally: Focused regressions passed `70/70`; all tests passed `750/750`; typecheck, build, architecture check, website lint/typecheck/build (`34` pages), root/site/runtime/consumer audits, npm registry signatures, and `git diff --check` passed. Clean local and global tarball installs passed version/help/package/search, stale-Pi upgrade, source and installed artifact verification, installed RPC/TypeBox tools, document parse/search/screenshot, and a fabricated agent-managed `brace-expansion@5.0.10` launch.
+- Package proof: Dry and real packs matched at `121,011,306` bytes, `342,270,111` unpacked bytes, and `40,223` entries. The tarball SHA-256 is `c7d1a439af9a9d70e3f90375efd03ba776f4af85e1d8346192861b3d4987c7e0`; the embedded runtime SHA-256 is `d803f701a3e32ff90a38d175891b413d83ca4f722ecf20f89f6b0ae2715f058d`.
+- Freshness: `pi-subagents@0.45.0` was reviewed but not adopted. Versions after bundled `0.40.0` remove public task/chain surfaces, make launches asynchronous by default, and add schedules, missions, Herdr, and administration paths. That broad contract migration has no issue-specific security or research-loop requirement. Other root and website drift has no current advisory or proven defect.
+- State: `verified` locally and `unverified` for the exact commit in Daytona, PR CI, merge, and npm/GitHub/native publication. Next: commit the candidate, prove that exact SHA in Daytona and CI, then merge, publish, verify delivery, and close `#217`.
+
 ### 2026-08-08 21:44 EDT — intake-sweep-0.3.12-release-completion
 
 - Objective: Complete issue `#214` through merge, publication, live delivery proof, and queue cleanup.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,17 @@ GitHub release notes are generated from the matching `## vX.Y.Z` section in this
 
 ## Unreleased
 
+## v0.3.13 - 2026-08-09
+
+### Reliability
+
+- Kept Pi agent-managed `brace-expansion` versions at or above the current secure `5.0.9` floor intact. A newer registry release can no longer stop Feynman during launch, while stale `5.0.6` through `5.0.8` trees still upgrade to the verified `5.0.9` package.
+- Kept malformed and older unsupported versions fail-closed instead of weakening the launch-time security repair.
+
+### Validation
+
+- Added source, package-lock, installed-tree, and exact agent-managed runtime regressions for future `brace-expansion` versions.
+
 ## v0.3.12 - 2026-08-08
 
 ### Research runtime

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@companion-ai/feynman",
-      "version": "0.3.12",
+      "version": "0.3.13",
       "bundleDependencies": [
         "@companion-ai/alpha-hub",
         "@earendil-works/pi-agent-core",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Research-first CLI agent built on Pi and alphaXiv",
   "license": "MIT",
   "type": "module",

--- a/scripts/lib/pi-shrinkwrap-security-patch.mjs
+++ b/scripts/lib/pi-shrinkwrap-security-patch.mjs
@@ -1,6 +1,7 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
+import { gte as semverGte, valid as validSemver } from "semver";
 
 const require = createRequire(import.meta.url);
 
@@ -12,6 +13,13 @@ const SAFE_BRACE_EXPANSION = {
 	dependencies: { "balanced-match": "^4.0.2" },
 	engines: { node: "20 || >=22" },
 };
+
+const PATCHABLE_BRACE_EXPANSION_VERSIONS = ["5.0.6", "5.0.7", "5.0.8"];
+
+function isSafeBraceExpansionVersion(version) {
+	const parsedVersion = validSemver(version);
+	return parsedVersion !== null && semverGte(parsedVersion, SAFE_BRACE_EXPANSION.version);
+}
 
 function readPackageVersion(packageRoot) {
 	try {
@@ -37,10 +45,10 @@ function resolveSafePackagePath(nodeModulesPath, fallbackSafePackagePath) {
 export function patchPiCodingAgentShrinkwrapSource(source) {
 	const shrinkwrap = JSON.parse(source);
 	const entry = shrinkwrap.packages?.["node_modules/brace-expansion"];
-	if (entry?.version === SAFE_BRACE_EXPANSION.version) {
+	if (isSafeBraceExpansionVersion(entry?.version)) {
 		return source;
 	}
-	if (!entry || !["5.0.6", "5.0.7", "5.0.8"].includes(entry.version)) {
+	if (!entry || !PATCHABLE_BRACE_EXPANSION_VERSIONS.includes(entry.version)) {
 		throw new Error(`Unsupported Pi brace-expansion shrinkwrap entry: ${entry?.version ?? "missing"}`);
 	}
 	shrinkwrap.packages["node_modules/brace-expansion"] = SAFE_BRACE_EXPANSION;
@@ -54,10 +62,10 @@ export function patchPiPackageLockSource(source) {
 		if (!packagePath.endsWith("/pi-coding-agent/node_modules/brace-expansion")) {
 			continue;
 		}
-		if (entry?.version === SAFE_BRACE_EXPANSION.version) {
+		if (isSafeBraceExpansionVersion(entry?.version)) {
 			continue;
 		}
-		if (!entry || !["5.0.6", "5.0.7", "5.0.8"].includes(entry.version)) {
+		if (!entry || !PATCHABLE_BRACE_EXPANSION_VERSIONS.includes(entry.version)) {
 			throw new Error(`Unsupported Pi brace-expansion package-lock entry: ${entry?.version ?? "missing"}`);
 		}
 		lockfile.packages[packagePath] = SAFE_BRACE_EXPANSION;
@@ -69,7 +77,7 @@ export function patchPiPackageLockSource(source) {
 /**
  * Older Pi releases shrinkwrap an affected brace-expansion release. Replace
  * only reviewed 5.0.6-5.0.8 trees with verified 5.0.9 for stale user runtimes.
- * Current Pi already ships 5.0.9, so this path is a no-op for bundled packages.
+ * Versions at or above 5.0.9 are outside the advisory range and remain intact.
  */
 export function patchPiBraceExpansionTree(nodeModulesPath, fallbackSafePackagePath) {
 	const piRoots = ["@earendil-works", "@mariozechner"]
@@ -87,8 +95,8 @@ export function patchPiBraceExpansionTree(nodeModulesPath, fallbackSafePackagePa
 		const patchedShrinkwrap = patchPiCodingAgentShrinkwrapSource(shrinkwrapSource);
 		const nestedPackagePath = resolve(piRoot, "node_modules", "brace-expansion");
 		const nestedVersion = readPackageVersion(nestedPackagePath);
-		if (nestedVersion !== SAFE_BRACE_EXPANSION.version) {
-			if (nestedVersion && !["5.0.6", "5.0.7", "5.0.8"].includes(nestedVersion)) {
+		if (!isSafeBraceExpansionVersion(nestedVersion)) {
+			if (nestedVersion && !PATCHABLE_BRACE_EXPANSION_VERSIONS.includes(nestedVersion)) {
 				throw new Error(`Unsupported installed Pi brace-expansion version: ${nestedVersion}`);
 			}
 			const safePackagePath = resolveSafePackagePath(nodeModulesPath, fallbackSafePackagePath);

--- a/tests/pi-runtime-patches.test.ts
+++ b/tests/pi-runtime-patches.test.ts
@@ -878,6 +878,59 @@ test("patchPiRuntimeNodeModules repairs current Pi Undici in global and agent ro
 	assert.equal(patchPiRuntimeNodeModules(appRoot, agentDir), false);
 });
 
+test("patchPiRuntimeNodeModules accepts newer brace-expansion in Pi's agent-managed root", () => {
+	const appRoot = mkdtempSync(join(tmpdir(), "feynman-agent-brace-forward-"));
+	const homeRoot = mkdtempSync(join(tmpdir(), "feynman-agent-brace-home-"));
+	const agentDir = join(homeRoot, ".feynman", "agent");
+	const bundledPiRoot = join(
+		appRoot,
+		"node_modules",
+		"@earendil-works",
+		"pi-coding-agent",
+	);
+	const agentPiRoot = join(
+		agentDir,
+		"npm",
+		"node_modules",
+		"@earendil-works",
+		"pi-coding-agent",
+	);
+	const agentBraceRoot = join(agentPiRoot, "node_modules", "brace-expansion");
+	const shrinkwrapSource = `${JSON.stringify({
+		lockfileVersion: 3,
+		packages: {
+			"node_modules/brace-expansion": {
+				version: "5.0.10",
+			},
+		},
+	}, null, 2)}\n`;
+	const manifestSource = `${JSON.stringify({
+		name: "brace-expansion",
+		version: "5.0.10",
+	}, null, 2)}\n`;
+	try {
+		mkdirSync(bundledPiRoot, { recursive: true });
+		mkdirSync(agentBraceRoot, { recursive: true });
+		writeFileSync(
+			join(bundledPiRoot, "package.json"),
+			JSON.stringify({ name: "@earendil-works/pi-coding-agent", version: "0.84.1" }),
+		);
+		writeFileSync(
+			join(agentPiRoot, "package.json"),
+			JSON.stringify({ name: "@earendil-works/pi-coding-agent", version: "0.80.6" }),
+		);
+		writeFileSync(join(agentPiRoot, "npm-shrinkwrap.json"), shrinkwrapSource);
+		writeFileSync(join(agentBraceRoot, "package.json"), manifestSource);
+
+		patchPiRuntimeNodeModules(appRoot, agentDir);
+		assert.equal(readFileSync(join(agentPiRoot, "npm-shrinkwrap.json"), "utf8"), shrinkwrapSource);
+		assert.equal(readFileSync(join(agentBraceRoot, "package.json"), "utf8"), manifestSource);
+	} finally {
+		rmSync(appRoot, { recursive: true, force: true });
+		rmSync(homeRoot, { recursive: true, force: true });
+	}
+});
+
 test("patchPiRuntimeNodeModules fails closed for unreviewed older and newer bundled Pi versions", () => {
 	for (const version of ["0.82.1", "0.84.0"]) {
 		const appRoot = mkdtempSync(join(tmpdir(), "feynman-unreviewed-pi-patches-"));

--- a/tests/pi-shrinkwrap-security-patch.test.ts
+++ b/tests/pi-shrinkwrap-security-patch.test.ts
@@ -38,6 +38,16 @@ test("Pi shrinkwrap security patch upgrades only vulnerable brace-expansion entr
 		},
 	}, null, 2)}\n`;
 	assert.equal(patchPiCodingAgentShrinkwrapSource(alreadySafe), alreadySafe);
+	for (const version of ["5.0.10", "6.0.0"]) {
+		const futureSafe = `${JSON.stringify({
+			packages: {
+				"node_modules/brace-expansion": {
+					version,
+				},
+			},
+		}, null, 2)}\n`;
+		assert.equal(patchPiCodingAgentShrinkwrapSource(futureSafe), futureSafe);
+	}
 	assert.throws(
 		() => patchPiCodingAgentShrinkwrapSource(JSON.stringify({
 			packages: { "node_modules/brace-expansion": { version: "4.0.0" } },
@@ -61,6 +71,14 @@ test("Pi shrinkwrap security patch upgrades the owning package lock", () => {
 		"5.0.9",
 	);
 	assert.equal(patchPiPackageLockSource(patchPiPackageLockSource(source)), patchPiPackageLockSource(source));
+	const futureSafe = `${JSON.stringify({
+		packages: {
+			"node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+				version: "5.0.10",
+			},
+		},
+	}, null, 2)}\n`;
+	assert.equal(patchPiPackageLockSource(futureSafe), futureSafe);
 });
 
 test("Pi shrinkwrap security patch replaces the nested package tree and is idempotent", () => {
@@ -108,6 +126,34 @@ test("Pi shrinkwrap security patch accepts a safe nested tree when npm hoists th
 	}));
 
 	assert.equal(patchPiBraceExpansionTree(nodeModules), false);
+});
+
+test("Pi shrinkwrap security patch leaves newer agent-managed trees intact", () => {
+	const root = mkdtempSync(join(tmpdir(), "feynman-pi-security-future-"));
+	const nodeModules = join(root, "node_modules");
+	const piRoot = join(nodeModules, "@earendil-works", "pi-coding-agent");
+	const nestedPackage = join(piRoot, "node_modules", "brace-expansion");
+	mkdirSync(nestedPackage, { recursive: true });
+	writeFileSync(join(nestedPackage, "package.json"), JSON.stringify({ name: "brace-expansion", version: "5.0.10" }));
+	writeFileSync(join(nestedPackage, "index.js"), "export const future = true;\n");
+	writeFileSync(join(piRoot, "npm-shrinkwrap.json"), JSON.stringify({
+		packages: { "node_modules/brace-expansion": { version: "5.0.10" } },
+	}));
+	writeFileSync(join(root, "package-lock.json"), JSON.stringify({
+		packages: {
+			"node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+				version: "5.0.10",
+			},
+		},
+	}));
+
+	assert.equal(patchPiBraceExpansionTree(nodeModules), false);
+	assert.equal(JSON.parse(readFileSync(join(nestedPackage, "package.json"), "utf8")).version, "5.0.10");
+	assert.equal(
+		JSON.parse(readFileSync(join(piRoot, "npm-shrinkwrap.json"), "utf8"))
+			.packages["node_modules/brace-expansion"].version,
+		"5.0.10",
+	);
 });
 
 test("embedded Pi dependency tree uses patched brace-expansion", () => {

--- a/website/src/content/docs/reference/releases.md
+++ b/website/src/content/docs/reference/releases.md
@@ -9,6 +9,17 @@ This page summarizes what changed in recent Feynman releases. GitHub releases us
 
 ## Unreleased
 
+## v0.3.13 - 2026-08-09
+
+### Reliability
+
+- Kept Pi agent-managed `brace-expansion` versions at or above the current secure `5.0.9` floor intact. A newer registry release can no longer stop Feynman during launch, while stale `5.0.6` through `5.0.8` trees still upgrade to the verified `5.0.9` package.
+- Kept malformed and older unsupported versions fail-closed instead of weakening the launch-time security repair.
+
+### Validation
+
+- Added source, package-lock, installed-tree, and exact agent-managed runtime regressions for future `brace-expansion` versions.
+
 ## v0.3.12 - 2026-08-08
 
 ### Research runtime


### PR DESCRIPTION
## Summary

- preserve valid Pi-managed `brace-expansion` versions at or above secure `5.0.9`
- continue upgrading reviewed vulnerable `5.0.6`–`5.0.8` trees to exact `5.0.9`
- fail closed for malformed and unsupported older versions
- cover Pi's exact `<agentDir>/npm` runtime path

Addresses #217.

## Evidence

- GitHub advisory `GHSA-rgw5-rvv9-x895` defines `5.0.9` as the patched 5.x floor.
- A fabricated agent-managed `5.0.10` tree now launches through installed Feynman RPC without mutation or startup failure.
- Stale `5.0.6` repair still passes twice through the installed-package smoke.

## Validation

- focused patch/runtime tests: 70 passed
- full `npm test`: 750 passed
- `npm run typecheck`
- `npm run build`
- `npm run architecture:check`
- website lint, typecheck, and build: 34 pages
- root, website, bundled-runtime, extracted-runtime, and clean-consumer production audits: 0 findings
- `git diff --check`
- dry and real npm packs
- clean local and global tarball installs
- installed package-artifact, RPC/TypeBox, document parse/search/screenshot, and stale-Pi verification

## Clean-machine proof

Daytona sandbox `99ff14c2-8913-405a-a45b-11f27518bd76` checked exact SHA `5177a12785972d09a023b35c418b8e57ea2390b9` on Linux x64 with Node `25.9.0`.

It passed all 750 tests, typecheck, build, architecture, website validation, all production audits, package build and verification, clean consumer/global installs, installed runtime/document tools, stale-Pi repair, and the fabricated `5.0.10` launch. The sandbox was deleted after verification.
