### PR TITLE
Clear Nano ID audit advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10327,9 +10327,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "fast-uri": "3.1.5",
     "esbuild": "0.28.1",
     "fast-xml-builder": "1.2.0",
+    "nanoid": "3.3.18",
     "protobufjs": "7.6.5",
     "undici": "8.10.0"
   },

--- a/tests/package-seeding.test.ts
+++ b/tests/package-seeding.test.ts
@@ -100,6 +100,7 @@ test("release manifests pin current document and website security repairs", () =
 	const manifest = JSON.parse(readFileSync(resolve(process.cwd(), "package.json"), "utf8")) as {
 		dependencies?: Record<string, string>;
 		optionalDependencies?: Record<string, string>;
+		overrides?: Record<string, string>;
 	};
 	const lock = JSON.parse(readFileSync(resolve(process.cwd(), "package-lock.json"), "utf8")) as {
 		packages?: Record<string, {
@@ -117,6 +118,8 @@ test("release manifests pin current document and website security repairs", () =
 
 	assert.equal(manifest.dependencies?.["pdfjs-dist"], "^6.2.108");
 	assert.equal(lock.packages?.["node_modules/pdfjs-dist"]?.version, "6.2.108");
+	assert.equal(manifest.overrides?.nanoid, "3.3.18");
+	assert.equal(lock.packages?.["node_modules/nanoid"]?.version, "3.3.18");
 	for (const packageName of [
 		"@llamaindex/liteparse-darwin-arm64",
 		"@llamaindex/liteparse-darwin-x64",
@@ -133,8 +136,8 @@ test("release manifests pin current document and website security repairs", () =
 	}
 	assert.equal(websiteManifest.overrides?.["js-yaml"], "4.3.1");
 	assert.equal(websiteLock.packages?.["node_modules/js-yaml"]?.version, "4.3.1");
-	assert.equal(websiteManifest.overrides?.nanoid, "3.3.17");
-	assert.equal(websiteLock.packages?.["node_modules/nanoid"]?.version, "3.3.17");
+	assert.equal(websiteManifest.overrides?.nanoid, "3.3.18");
+	assert.equal(websiteLock.packages?.["node_modules/nanoid"]?.version, "3.3.18");
 });
 
 test("prepare runtime workspace links legacy Pi aliases instead of installing duplicates", async () => {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9046,9 +9046,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/website/package.json
+++ b/website/package.json
@@ -52,7 +52,7 @@
     "vite": "8.1.5",
     "body-parser": "2.3.0",
     "js-yaml": "4.3.1",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "yaml": "2.8.3",
     "fast-uri": "3.1.5",
     "sharp": "0.35.3",


### PR DESCRIPTION
## What changed

- pin Nano ID 3.3.18 in the root and website dependency graphs
- refresh both lockfiles
- extend the package security regression to enforce the patched version

This clears GHSA-2v37-7h3g-55p8. Version 3.3.18 also covers the React Native async path omitted from 3.3.17.

## Verification

- focused package regression: 15/15
- full root and website audits: 0 vulnerabilities
- exact SHA `ed067e14bb29e1aad88b81b59d563fa04f883e9c` in Daytona: 750/750 tests, typecheck, build, architecture, website lint/typecheck/build, all audits
- clean tarball consumer and global installs: package/runtime/RPC/TypeBox/document checks passed
- tarball SHA-256: `31dcd53fcb6147f0ab87b675531a6679287300f6291366b714448d76f331e683`
