### PR TITLE
Allow slow Windows package installs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -353,7 +353,7 @@ jobs:
     if: github.event_name == 'pull_request'
     needs: release-candidate-pr
     name: Candidate consumer (${{ matrix.os }}, Node ${{ matrix.node }})
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -300,7 +300,7 @@ jobs:
     needs:
       - version-check
       - verify
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Workspace lab notebook for long-running or resumable research work.
 
 Use this file to track chronology, not release notes. Keep entries short, factual, and operational.
 
+### 2026-08-11 11:28 EDT — intake-sweep-windows-consumer-budget-0.3.18
+
+- Objective: Resume the `0.3.18` publication after main run `31499996075` exhausted its Windows Node `25` consumer job budget.
+- Evidence: The first clean tarball install passed after `33` minutes. The second clean global install was still running when GitHub cancelled the job at `60` minutes. The same matrix completed in prior runs when both installs finished sooner.
+- Changed: Raised the PR and publish package-consumer job budgets from `60` to `90` minutes. All local/global install, audit, package, runtime, RPC, TypeBox, and document gates remain unchanged.
+- State: `unverified` for the successor PR and publish run. Next: pass focused and cumulative checks, merge exact green CI, then finish npm/GitHub/native publication and post-release proof.
+
 ### 2026-08-11 01:35 EDT — intake-sweep-web-cache-hardening-0.3.17
 
 - Objective: Complete the post-`0.3.16` fetched-content reliability intake without broadening Feynman beyond the research loop.

--- a/tests/release-workflows.test.ts
+++ b/tests/release-workflows.test.ts
@@ -156,18 +156,18 @@ test("package gates exercise the global npm install path", () => {
 	assert.match(publishWorkflow, /"@companion-ai\/feynman@\$VERSION"/);
 });
 
-test("package consumer matrices allow bounded Windows global-install time", () => {
+test("package consumer matrices allow two slow Windows package installs", () => {
 	const candidateConsumerJob = e2eWorkflow.match(
 		/\n  supported-node-consumers-pr:[\s\S]*?(?=\n  windows-native-installer-pr:)/,
 	);
 	assert.ok(candidateConsumerJob, "PR workflow must define the candidate consumer job");
-	assert.match(candidateConsumerJob[0], /\n    timeout-minutes: 60\n/);
+	assert.match(candidateConsumerJob[0], /\n    timeout-minutes: 90\n/);
 
 	const releaseConsumerJob = publishWorkflow.match(
 		/\n  verify-package-consumers:[\s\S]*?(?=\n  publish-npm:)/,
 	);
 	assert.ok(releaseConsumerJob, "publish workflow must define the package consumer job");
-	assert.match(releaseConsumerJob[0], /\n    timeout-minutes: 60\n/);
+	assert.match(releaseConsumerJob[0], /\n    timeout-minutes: 90\n/);
 });
 
 test("publish uses the exact verified tarball after native bundles pass", () => {


### PR DESCRIPTION
## Summary

- allow both clean Windows package installs to finish on slow hosted runners
- keep every local/global audit, runtime, RPC, TypeBox, and document gate unchanged
- enforce the shared PR and publish budget in workflow contract tests

## Evidence

Publish run `31499996075` installed the local Windows Node 25 consumer in 33 minutes. Its clean global install was still running when the 60-minute job budget cancelled it. Prior release runs passed the same two installs when runner extraction was faster.

## Verification

- release workflow tests: 12/12
- full tests: 770/770
- typecheck, build, architecture check, and actionlint
- website lint, typecheck, and 34-page build
- root, website, runtime, consumer, and extracted-runtime production audits: 0 vulnerabilities
- dry and real packs matched: 121,036,187 bytes, 342,335,070 unpacked bytes, 40,224 files
- package SHA-256: `a9eb0dea17141d1763bddd562ec69486751bd07738d625760772655bd85d13fd`
- local and global installed runtime, RPC, TypeBox, document parser, stale-Pi, and researcher extension path gates
